### PR TITLE
refactor: migrate cam listings to BeautifulSoup

### DIFF
--- a/plugin.video.cumination/resources/lib/sites/cambro.py
+++ b/plugin.video.cumination/resources/lib/sites/cambro.py
@@ -17,6 +17,7 @@
 '''
 
 import re
+from six.moves import urllib_parse
 from resources.lib import utils
 from resources.lib.decrypters.kvsplayer import kvs_decode
 from resources.lib.adultsite import AdultSite
@@ -38,28 +39,83 @@ def Main():
 @site.register()
 def List(url):
     listhtml = utils.getHtml(url)
-    match = re.compile(r'class="item(.+?)href="([^"]+)"\s*title="([^"]+)".+?data-original="([^"]+)".+?duration">([^<]+)<(.+?)"views"', re.DOTALL | re.IGNORECASE).findall(listhtml)
-    for priv, video, name, img, duration, hd in match:
-        if 'private' in priv:
+    soup = utils.parse_html(listhtml)
+
+    seen = set()
+    items = soup.select('div.item')
+    for item in items:
+        classes = [cls.lower() for cls in item.get('class', [])]
+        if any('private' in cls for cls in classes):
             continue
-        hd = 'HD' if '>HD<' in hd else ''
-        name = utils.cleantext(name)
+
+        link = item.select_one('a[href]')
+        if not link:
+            continue
+
+        video = utils.safe_get_attr(link, 'href')
+        if not video:
+            continue
+        video = urllib_parse.urljoin(url, video)
+        if video in seen:
+            continue
+        seen.add(video)
+
+        name = utils.safe_get_attr(link, 'title')
+        if not name:
+            title_tag = item.select_one('.title, .video-title, h3')
+            name = utils.safe_get_text(title_tag)
+        if not name:
+            name = utils.safe_get_text(link)
+        name = utils.cleantext(name) if name else 'Video'
+
+        img_tag = item.select_one('img[data-original], img[data-src], img[src]')
+        img = utils.safe_get_attr(img_tag, 'data-original', ['data-src', 'src'])
+        if img and img.startswith('//'):
+            img = 'https:' + img
+
+        duration_tag = item.select_one('.duration, .time, .video-duration, .value')
+        duration = utils.safe_get_text(duration_tag)
+
+        hd = ''
+        if item.select_one('.hd, .is-hd, .label-hd, .video-hd, .quality-hd, .hd-icon'):
+            hd = 'HD'
+        elif ' HD' in item.get_text(' ', strip=True).upper():
+            hd = 'HD'
+
         site.add_download_link(name, video, 'Playvid', img, name, duration=duration, quality=hd)
 
-    nextp = re.compile(r':(\d+)">Next', re.DOTALL | re.IGNORECASE).findall(listhtml)
-    if nextp:
-        np = nextp[0]
-        pg = int(np) - 1
-        r = re.search(r'/\d+/', url)
-        if r:
-            next_page = re.sub(r'/\d+/', '/{0}/'.format(np), url)
-        elif 'from_videos={0:02d}'.format(pg) in url:
-            next_page = url.replace('from_videos={0:02d}'.format(pg), 'from_videos={0:02d}'.format(int(np)))
-        else:
-            next_page = url + '{0}/'.format(np)
-        lp = re.compile(r':(\d+)">Last', re.DOTALL | re.IGNORECASE).findall(listhtml)
-        lp = '/' + lp[0] if lp else ''
-        site.add_dir('Next Page (' + np + lp + ')', next_page, 'List', site.img_next)
+    pagination = soup.select_one('.pagination')
+    if pagination:
+        next_link = pagination.select_one('li.next a, a.next, a[rel="next"]')
+        if next_link:
+            next_href = utils.safe_get_attr(next_link, 'href')
+            if next_href:
+                next_page = urllib_parse.urljoin(url, next_href)
+                page_num = None
+                match = re.search(r'/([0-9]+)/?$', next_page.rstrip('/'))
+                if match:
+                    page_num = match.group(1)
+                else:
+                    match = re.search(r'from_(?:videos|items)=([0-9]+)', next_page)
+                    if match:
+                        page_num = str(int(match.group(1)))
+
+                last_link = pagination.select_one('li.last a, a.last')
+                last_num = None
+                if last_link:
+                    last_href = utils.safe_get_attr(last_link, 'href')
+                    if last_href:
+                        lm = re.search(r'/([0-9]+)/?$', last_href.rstrip('/'))
+                        if lm:
+                            last_num = lm.group(1)
+
+                if page_num and last_num:
+                    label = 'Next Page ({}/{})'.format(page_num, last_num)
+                elif page_num:
+                    label = 'Next Page ({})'.format(page_num)
+                else:
+                    label = 'Next Page'
+                site.add_dir(label, next_page, 'List', site.img_next)
 
     utils.eod()
 
@@ -67,22 +123,70 @@ def List(url):
 @site.register()
 def List2(url):
     listhtml = utils.getHtml(url)
-    match = re.compile(r'class="item.+?item="([^"]+).+?original="([^"]+).+?title">\s*([^<\n]+)', re.DOTALL | re.IGNORECASE).findall(listhtml)
-    for video, img, name in match:
-        name = utils.cleantext(name)
+    soup = utils.parse_html(listhtml)
+
+    seen = set()
+    items = soup.select('div.item')
+    for item in items:
+        video = item.get('data-item')
+        if not video:
+            link = item.select_one('a[href]')
+            video = utils.safe_get_attr(link, 'href') if link else None
+        if not video:
+            continue
+        video = urllib_parse.urljoin(url, video)
+        if video in seen:
+            continue
+        seen.add(video)
+
+        img_tag = item.select_one('img[data-original], img[data-src], img[src]')
+        img = utils.safe_get_attr(img_tag, 'data-original', ['data-src', 'src'])
+        if img and img.startswith('//'):
+            img = 'https:' + img
+
+        title_tag = item.select_one('.title, .video-title, a[title]')
+        name = utils.safe_get_attr(title_tag, 'title') if title_tag else None
+        if not name:
+            name = utils.safe_get_text(title_tag)
+        if not name:
+            link = item.select_one('a[href]')
+            name = utils.safe_get_attr(link, 'title') or utils.safe_get_text(link)
+        name = utils.cleantext(name) if name else 'Video'
+
         site.add_download_link(name, video, 'Playvid', img, name)
 
-    nextp = re.compile(r':(\d+)">Next', re.DOTALL | re.IGNORECASE).findall(listhtml)
-    if nextp:
-        np = nextp[0]
-        pg = int(np) - 1
-        if 'from={0:02d}'.format(pg) in url:
-            next_page = url.replace('from={0:02d}'.format(pg), 'from={0:02d}'.format(int(np)))
-        else:
-            next_page = url + '{0}/'.format(np)
-        lp = re.compile(r':(\d+)">Last', re.DOTALL | re.IGNORECASE).findall(listhtml)
-        lp = '/' + lp[0] if lp else ''
-        site.add_dir('Next Page (' + np + lp + ')', next_page, 'List2', site.img_next)
+    pagination = soup.select_one('.pagination')
+    if pagination:
+        next_link = pagination.select_one('li.next a, a.next, a[rel="next"]')
+        if next_link:
+            next_href = utils.safe_get_attr(next_link, 'href')
+            if next_href:
+                next_page = urllib_parse.urljoin(url, next_href)
+                page_num = None
+                match = re.search(r'/([0-9]+)/?$', next_page.rstrip('/'))
+                if match:
+                    page_num = match.group(1)
+                else:
+                    match = re.search(r'from=([0-9]+)', next_page)
+                    if match:
+                        page_num = match.group(1)
+
+                last_link = pagination.select_one('li.last a, a.last')
+                last_num = None
+                if last_link:
+                    last_href = utils.safe_get_attr(last_link, 'href')
+                    if last_href:
+                        lm = re.search(r'/([0-9]+)/?$', last_href.rstrip('/'))
+                        if lm:
+                            last_num = lm.group(1)
+
+                if page_num and last_num:
+                    label = 'Next Page ({}/{})'.format(page_num, last_num)
+                elif page_num:
+                    label = 'Next Page ({})'.format(page_num)
+                else:
+                    label = 'Next Page'
+                site.add_dir(label, next_page, 'List2', site.img_next)
 
     utils.eod()
 
@@ -90,23 +194,75 @@ def List2(url):
 @site.register()
 def Playlist(url):
     listhtml = utils.getHtml(url)
-    match = re.compile(r'class="item.+?href="([^"]+).+?data-original="([^"]+).+?title">\s*([^<\n]+).+?videos">([^<]+)', re.DOTALL | re.IGNORECASE).findall(listhtml)
-    for lpage, img, name, count in match:
-        name = utils.cleantext(name) + "[COLOR deeppink] {0}[/COLOR]".format(count)
-        lpage += '?mode=async&function=get_block&block_id=playlist_view_playlist_view&sort_by=&from=01'
+    soup = utils.parse_html(listhtml)
+
+    seen = set()
+    items = soup.select('div.item')
+    for item in items:
+        link = item.select_one('a[href]')
+        if not link:
+            continue
+        lpage = utils.safe_get_attr(link, 'href')
+        if not lpage:
+            continue
+        lpage = urllib_parse.urljoin(url, lpage)
+        if lpage in seen:
+            continue
+        seen.add(lpage)
+
+        img_tag = item.select_one('img[data-original], img[data-src], img[src]')
+        img = utils.safe_get_attr(img_tag, 'data-original', ['data-src', 'src'])
+        if img and img.startswith('//'):
+            img = 'https:' + img
+
+        title_tag = item.select_one('.title, .video-title, a[title]')
+        name = utils.safe_get_attr(title_tag, 'title') if title_tag else None
+        if not name:
+            name = utils.safe_get_text(title_tag)
+        if not name:
+            name = utils.safe_get_attr(link, 'title') or utils.safe_get_text(link)
+        name = utils.cleantext(name) if name else 'Playlist'
+
+        count_tag = item.select_one('.videos, .totalplaylist, .count, .video-count')
+        count = utils.safe_get_text(count_tag)
+        if count:
+            name = name + "[COLOR deeppink] {0}[/COLOR]".format(count)
+
+        lpage = lpage + '?mode=async&function=get_block&block_id=playlist_view_playlist_view&sort_by=&from=01'
         site.add_dir(name, lpage, 'List2', img)
 
-    nextp = re.compile(r':(\d+)">Next', re.DOTALL | re.IGNORECASE).findall(listhtml)
-    if nextp:
-        np = nextp[0]
-        pg = int(np) - 1
-        if 'from={0:02d}'.format(pg) in url:
-            next_page = url.replace('from={0:02d}'.format(pg), 'from={0:02d}'.format(int(np)))
-        else:
-            next_page = url + '{0}/'.format(np)
-        lp = re.compile(r':(\d+)">Last', re.DOTALL | re.IGNORECASE).findall(listhtml)
-        lp = '/' + lp[0] if lp else ''
-        site.add_dir('Next Page (' + np + lp + ')', next_page, 'Playlist', site.img_next)
+    pagination = soup.select_one('.pagination')
+    if pagination:
+        next_link = pagination.select_one('li.next a, a.next, a[rel="next"]')
+        if next_link:
+            next_href = utils.safe_get_attr(next_link, 'href')
+            if next_href:
+                next_page = urllib_parse.urljoin(url, next_href)
+                page_num = None
+                match = re.search(r'/([0-9]+)/?$', next_page.rstrip('/'))
+                if match:
+                    page_num = match.group(1)
+                else:
+                    match = re.search(r'from=([0-9]+)', next_page)
+                    if match:
+                        page_num = match.group(1)
+
+                last_link = pagination.select_one('li.last a, a.last')
+                last_num = None
+                if last_link:
+                    last_href = utils.safe_get_attr(last_link, 'href')
+                    if last_href:
+                        lm = re.search(r'/([0-9]+)/?$', last_href.rstrip('/'))
+                        if lm:
+                            last_num = lm.group(1)
+
+                if page_num and last_num:
+                    label = 'Next Page ({}/{})'.format(page_num, last_num)
+                elif page_num:
+                    label = 'Next Page ({})'.format(page_num)
+                else:
+                    label = 'Next Page'
+                site.add_dir(label, next_page, 'Playlist', site.img_next)
 
     utils.eod()
 
@@ -125,8 +281,14 @@ def Search(url, keyword=None):
 @site.register()
 def Tags(url):
     html = utils.getHtml(url)
-    match = re.compile(r'<li>\s*<a\s*href="([^"]+)">([^<]+)</a>\s*</li>', re.DOTALL | re.IGNORECASE).findall(html)
-    for tagpage, name in match:
+    soup = utils.parse_html(html)
+
+    for anchor in soup.select('li a[href]'):
+        tagpage = utils.safe_get_attr(anchor, 'href')
+        if not tagpage:
+            continue
+        tagpage = urllib_parse.urljoin(url, tagpage)
+        name = utils.safe_get_text(anchor)
         name = utils.cleantext(name)
         site.add_dir(name, tagpage, 'List')
     utils.eod()
@@ -135,9 +297,38 @@ def Tags(url):
 @site.register()
 def Categories(url):
     cathtml = utils.getHtml(url)
-    match = re.compile(r'<a\s*class="item"\s*href="([^"]+)"\s*title="([^"]+)">.+?src="([^"]+)".+?class="videos">([^<]+)<', re.DOTALL | re.IGNORECASE).findall(cathtml)
-    for catpage, name, img, videos in match:
-        name = utils.cleantext(name) + " [COLOR deeppink]" + videos + "[/COLOR]"
+    soup = utils.parse_html(cathtml)
+
+    seen = set()
+    for anchor in soup.select('a.item[href], div.item a[href]'):
+        catpage = utils.safe_get_attr(anchor, 'href')
+        if not catpage:
+            continue
+        catpage = urllib_parse.urljoin(url, catpage)
+        if catpage in seen:
+            continue
+        seen.add(catpage)
+
+        name = utils.safe_get_attr(anchor, 'title')
+        if not name:
+            title_tag = anchor.select_one('.title, .video-title') if hasattr(anchor, 'select_one') else None
+            name = utils.safe_get_text(title_tag) if title_tag else utils.safe_get_text(anchor)
+        name = utils.cleantext(name) if name else 'Category'
+
+        parent = anchor
+        if anchor.parent and hasattr(anchor.parent, 'select_one'):
+            parent = anchor.parent
+
+        img_tag = parent.select_one('img[data-original], img[data-src], img[src]')
+        img = utils.safe_get_attr(img_tag, 'data-original', ['data-src', 'src']) if img_tag else None
+        if img and img.startswith('//'):
+            img = 'https:' + img
+
+        count_tag = parent.select_one('.videos, .count, .totalplaylist, .video-count')
+        videos = utils.safe_get_text(count_tag)
+        if videos:
+            name = name + " [COLOR deeppink]" + videos + "[/COLOR]"
+
         site.add_dir(name, catpage, 'List', img)
     utils.eod()
 
@@ -145,17 +336,68 @@ def Categories(url):
 @site.register()
 def Models(url):
     html = utils.getHtml(url)
-    match = re.compile(r'class="item"\s*href="([^"]+)".+?(?:src="([^"]+)"|>no image<).+?class="title">([^<]+)<.+?"videos">([^<]+)<', re.DOTALL | re.IGNORECASE).findall(html)
-    for murl, img, name, videos in match:
-        name = utils.cleantext(name) + " [COLOR deeppink]" + videos + "[/COLOR]"
+    soup = utils.parse_html(html)
+
+    seen = set()
+    items = soup.select('div.item')
+    for item in items:
+        link = item.select_one('a[href]')
+        if not link:
+            continue
+        murl = utils.safe_get_attr(link, 'href')
+        if not murl:
+            continue
+        murl = urllib_parse.urljoin(url, murl)
+        if murl in seen:
+            continue
+        seen.add(murl)
+
+        img_tag = item.select_one('img[src], img[data-src], img[data-original]')
+        img = utils.safe_get_attr(img_tag, 'src', ['data-src', 'data-original']) if img_tag else None
+        if img and img.startswith('//'):
+            img = 'https:' + img
+
+        title_tag = item.select_one('.title, .model-name, a[title]')
+        name = utils.safe_get_attr(title_tag, 'title') if title_tag else None
+        if not name:
+            name = utils.safe_get_text(title_tag)
+        if not name:
+            name = utils.safe_get_attr(link, 'title') or utils.safe_get_text(link)
+        name = utils.cleantext(name) if name else 'Model'
+
+        count_tag = item.select_one('.videos, .count, .video-count')
+        videos = utils.safe_get_text(count_tag)
+        if videos:
+            name = name + " [COLOR deeppink]" + videos + "[/COLOR]"
+
         site.add_dir(name, murl, 'List', img)
 
-    nextp = re.compile(r'class="pagination".+?next".+?(\d+)"', re.DOTALL | re.IGNORECASE).search(html)
-    if nextp:
-        np = nextp.group(1)
-        next_page = re.sub(r'/\d+/', '/{0}/'.format(np), url)
-        lp = re.compile(r'class="pagination".+?last".+?(\d+)"', re.DOTALL | re.IGNORECASE).findall(html)[0]
-        site.add_dir('Next Page ( ' + np + ' / ' + lp + ' )', next_page, 'Models', site.img_next)
+    pagination = soup.select_one('.pagination')
+    if pagination:
+        next_link = pagination.select_one('li.next a, a.next, a[rel="next"]')
+        last_link = pagination.select_one('li.last a, a.last')
+        if next_link:
+            next_href = utils.safe_get_attr(next_link, 'href')
+            if next_href:
+                next_page = urllib_parse.urljoin(url, next_href)
+                next_num = None
+                nm = re.search(r'/([0-9]+)/?$', next_page.rstrip('/'))
+                if nm:
+                    next_num = nm.group(1)
+                last_num = None
+                if last_link:
+                    last_href = utils.safe_get_attr(last_link, 'href')
+                    if last_href:
+                        lm = re.search(r'/([0-9]+)/?$', last_href.rstrip('/'))
+                        if lm:
+                            last_num = lm.group(1)
+                if next_num and last_num:
+                    label = 'Next Page ( {0} / {1} )'.format(next_num, last_num)
+                elif next_num:
+                    label = 'Next Page ({})'.format(next_num)
+                else:
+                    label = 'Next Page'
+                site.add_dir(label, next_page, 'Models', site.img_next)
 
     utils.eod()
 


### PR DESCRIPTION
## Summary
- refactor Cambro listings, playlists, tags and categories to use BeautifulSoup selectors with duplicate guards and cleaner pagination
- migrate CamWhoresBay listing, category and playlist scrapers to BeautifulSoup while preserving private/favorites context handling
- update RealLifeCam listings, category browser and iframe resolution to BeautifulSoup parsing for more resilient scraping

## Testing
- python -m compileall plugin.video.cumination/resources/lib/sites/cambro.py plugin.video.cumination/resources/lib/sites/camwhoresbay.py plugin.video.cumination/resources/lib/sites/reallifecam.py

------
https://chatgpt.com/codex/tasks/task_e_690922f78218832784c20db21fdc7646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of video content extraction and display across sources
  * Eliminated duplicate videos from appearing in listings
  * Enhanced private content filtering
  * Fixed thumbnail image loading and URL handling

* **New Features**
  * Improved HD detection accuracy
  * Enhanced pagination with clearer page information display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->