### PR TITLE
Add GitHub Action to build Kodi add-on zips

### DIFF
--- a/.github/workflows/build-addons.yml
+++ b/.github/workflows/build-addons.yml
@@ -1,0 +1,46 @@
+name: Build Kodi Add-on Packages
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+
+jobs:
+  build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+
+      - name: Build add-on archives
+        run: |
+          python build_repo_addons.py --out build/addons --update-index
+
+      - name: Collect build artifacts
+        run: |
+          mkdir -p upload
+          cp addons.xml addons.xml.md5 upload/
+          cp build/addons/*.zip upload/
+
+      - name: Upload packages artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kodi-addons
+          path: upload
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
## Summary
- add a workflow that builds the Kodi add-on packages with build_repo_addons.py when commits land on the default branches or a PR is merged
- upload the generated ZIP files and updated addon index as a downloadable workflow artifact

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ce7017c483278dae3084d08d6fb9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated add-on compilation and packaging workflow triggered on repository updates and manual invocation. Build artifacts are retained for 7 days and prepared for distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->