### PR TITLE
Migrate JustPorn site to BeautifulSoup

### DIFF
--- a/CHANGES_v1.1.166.md
+++ b/CHANGES_v1.1.166.md
@@ -46,7 +46,7 @@
 ---
 
 ## 📈 Roadmap Impact
-- BeautifulSoup migration progress: **22/137 sites (16.1%) - Phase 2 60% complete**.
+- BeautifulSoup migration progress: **24/137 sites (17.5%) - Phase 2 60% complete**.
 - Next focus: Continue Phase 2 mainstream providers (12 remaining sites).
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@
 
 **Started**: 2025-11-01
 **Current Version**: v1.1.181
-**Progress**: 22/137 sites (16.1%) migrated
+**Progress**: 24/137 sites (17.5%) migrated
 
 ---
 
@@ -346,9 +346,9 @@ Part of BeautifulSoup migration roadmap (site X/137)
 ### Overall Progress
 
 - **Total Sites**: 137
-- **Completed**: 22 (16.1%)
+- **Completed**: 24 (17.5%)
 - **In Progress**: 0
-- **Remaining**: 115 (83.9%)
+- **Remaining**: 113 (82.5%)
 
 ### Phase Progress
 
@@ -357,7 +357,7 @@ Part of BeautifulSoup migration roadmap (site X/137)
 | Phase 0: Infrastructure | 3 items | 3 | 100% ✅ |
 | Phase 1: High Priority | 10 | 8 | 80% 🚧 |
 | Phase 2: Medium Priority | 20 | 12 | 60% 🚀 |
-| Phase 3: Live Cams | 8 | 0 | 0% |
+| Phase 3: Live Cams | 8 | 1 | 12.5% |
 | Phase 4: JAV Sites | 20 | 0 | 0% |
 | Phase 5: Hentai/Anime | 10 | 0 | 0% |
 | Phase 6: International | 15 | 0 | 0% |


### PR DESCRIPTION
## Summary
- migrate the JustPorn listing parser to BeautifulSoup selectors while preserving quality/duration detection
- update the JustPorn categories handler to use BeautifulSoup and maintain alphabetical ordering
- refresh the roadmap and changelog to record the JustPorn migration and updated Phase 2 progress numbers

## Testing
- python3 -m compileall plugin.video.cumination/resources/lib/sites/justporn.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910d909c7e08327ab8a04eb6fdc310c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Justporn site is now supported.

* **Documentation**
  * Roadmap updated: 22/137 sites migrated (16.1%); Phase 2 progress at 60%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->