### PR TITLE
tests: add fixtures for migrated sites

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,7 @@ if str(PLUGIN_PATH) not in sys.path:
     sys.path.insert(0, str(PLUGIN_PATH))
 
 # Kodi-style scripts rely on positional argv entries provided by Kodi.
-if len(sys.argv) < 3:
-    sys.argv = ['plugin.video.cumination', '1', '']
+sys.argv = ['plugin.video.cumination', '1', '']
 
 
 def _ensure_kodi_stubs():

--- a/tests/fixtures/sites/eporner/listing.html
+++ b/tests/fixtures/sites/eporner/listing.html
@@ -1,0 +1,15 @@
+<html>
+  <body>
+    <div class="mb" data-vp="1">
+      <div class="mbcontent">
+        <a href="/video/ep1">
+          <img data-src="https://img.example.com/ep1.jpg" />
+        </a>
+      </div>
+      <div class="mbtit"><a>Sample Eporner Video</a></div>
+      <div class="mbstats"><span class="mbtim">10:05</span></div>
+      <div class="mvhdico"><span>1080p</span></div>
+    </div>
+    <a class="nmnext" href="/recent/2/">next</a>
+  </body>
+</html>

--- a/tests/fixtures/sites/hqporner/listing.html
+++ b/tests/fixtures/sites/hqporner/listing.html
@@ -1,0 +1,14 @@
+<html>
+  <body>
+    <section class="box feature">
+      <a class="image featured" href="/videos/hq-1">
+        <img src="//cdn.hqporner.com/cover.jpg" />
+      </a>
+      <div class="meta-data-title"><a>HQ Clip</a></div>
+      <span class="icon fa-clock-o">15:10</span>
+    </section>
+    <ul class="actions pagination">
+      <li><a class="button mobile-pagi" href="/hdporn/2">Next</a></li>
+    </ul>
+  </body>
+</html>

--- a/tests/fixtures/sites/justporn/listing.html
+++ b/tests/fixtures/sites/justporn/listing.html
@@ -1,0 +1,12 @@
+<html>
+  <body>
+    <div class="content video-item">
+      <a href="/videos/jp-1">
+        <img data-src="https://justporn.img/1.jpg" />
+      </a>
+      <h2><a>Justporn Sample</a></h2>
+      <div class="duration">09:00</div>
+      <div class="quality">4K</div>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/sites/porntrex/listing.html
+++ b/tests/fixtures/sites/porntrex/listing.html
@@ -1,0 +1,19 @@
+<html>
+  <body>
+    <div id="list_videos_latest_videos_list_norm">
+      <div class="video-preview-screen">
+        <a class="thumb" href="https://www.porntrex.com/videos/alpha">
+          <img class="cover" data-src="//img.porntrex.com/a1.jpg" />
+        </a>
+        <p class="inf"><a>Alpha Entry</a></p>
+        <div class="hd-text-icon"><span class="quality">4K</span></div>
+        <div class="durations"><span>3 days ago</span><span>11:00</span></div>
+        <ul class="list-unstyled"><li>2 days ago</li></ul>
+      </div>
+    </div>
+    <div id="list_videos_latest_videos_list_norm_pagination">
+      <a href="/latest-updates/2" class="page">2</a>
+      <a href="/latest-updates/3" class="page">3</a>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/sites/spankbang/listing.html
+++ b/tests/fixtures/sites/spankbang/listing.html
@@ -1,0 +1,17 @@
+<html>
+  <body>
+    <div data-testid="video-item">
+      <a href="/video/alpha">
+        <img data-src="https://img.example.com/a.jpg" />
+      </a>
+      <p><a title="Alpha Clip">Alpha Clip</a></p>
+      <span data-testid="video-item-length">08:15</span>
+      <span data-testid="video-item-resolution">1080p</span>
+    </div>
+    <div class="pagination">
+      <ul>
+        <li class="next"><a href="/new_videos/2/?o=new">next</a></li>
+      </ul>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/sites/sxyprn/listing.html
+++ b/tests/fixtures/sites/sxyprn/listing.html
@@ -1,0 +1,15 @@
+<html>
+  <body>
+    <div class="post_el_small">
+      <a href="/blog/all/123.html" title="Sample Title">
+        <img data-src="//img.sxyprn.com/thumb.jpg" />
+      </a>
+      <span class="duration_small">07:21</span>
+      <span class="bitrate">HD</span>
+    </div>
+    <div class="ctrl">
+      <a class="ctrl_el ctrl_sel" href="/blog/all/0.html">1</a>
+      <a class="ctrl_el" href="/blog/all/1.html">2</a>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/sites/whoreshub/listing.html
+++ b/tests/fixtures/sites/whoreshub/listing.html
@@ -1,0 +1,15 @@
+<html>
+  <body>
+    <div class="box">
+      <a class="item" href="https://www.whoreshub.com/videos/alpha" title="Alpha Whoreshub">
+        <img data-src="//wh.img/alpha.jpg" />
+        <div class="duration">09:45</div>
+        <div class="is-hd">HD</div>
+      </a>
+    </div>
+    <ul class="pagination">
+      <li class="current"><span>1</span></li>
+      <li class="next"><a data-block-id="list_videos_common_videos_list" data-parameters="from_videos=1" href="#">Next</a></li>
+    </ul>
+  </body>
+</html>

--- a/tests/fixtures/sites/xhamster/listing.html
+++ b/tests/fixtures/sites/xhamster/listing.html
@@ -1,0 +1,26 @@
+<html>
+  <body>
+    <script>
+      window.initials={
+        "layoutPage":{
+          "videoListProps":{
+            "videoThumbProps":[
+              {
+                "title":"Hamster Clip",
+                "pageURL":"https://xhamster.com/videos/example",
+                "thumbURL":"https://xhcdn.com/thumb.jpg",
+                "duration":180,
+                "isHD":true
+              }
+            ]
+          },
+          "categoryInfoProps":{"pageTitle":"Newest"},
+          "paginationProps":{
+            "currentPageNumber":1,
+            "lastPageNumber":2,
+            "pageLinkTemplate":"https://xhamster.com/newest/{#}"
+          }
+        }
+      };</script>
+  </body>
+</html>

--- a/tests/fixtures/sites/xnxx/listing.html
+++ b/tests/fixtures/sites/xnxx/listing.html
@@ -1,0 +1,25 @@
+<html>
+  <body>
+    <div class="mozaique">
+      <div class="thumb-block">
+        <div class="thumb">
+          <a href="/video123" title="Video 123">
+            <img data-src="//thumbs.example.com/123.jpg" />
+          </a>
+        </div>
+        <div class="thumb-under">
+          <p class="title"><a href="/video123">First Clip</a></p>
+          <div class="metadata">
+            <span>12 min</span>
+            <span>HD</span>
+          </div>
+          <span class="video-hd">HD</span>
+        </div>
+      </div>
+    </div>
+    <div class="pagination">
+      <a class="no-page next" href="/page2"></a>
+      <a class="last-page">8</a>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/sites/xvideos/listing.html
+++ b/tests/fixtures/sites/xvideos/listing.html
@@ -1,0 +1,28 @@
+<html>
+  <body>
+    <div class="thumb-block">
+      <a href="/videos/example-1" title="Example One">
+        <img data-src="//cdn.example.com/thumb1.jpg" />
+        <div class="duration">12:34</div>
+        <span class="video-hd-mark">HD</span>
+      </a>
+      <div class="thumb-under">
+        <p class="title"><a title="Example One" href="/videos/example-1">Example One</a></p>
+        <div class="metadata">12 min - Category One</div>
+      </div>
+    </div>
+    <div class="thumb-block">
+      <a href="/videos/example-2" title="Example Two">
+        <img data-src="//cdn.example.com/thumb2.jpg" />
+      </a>
+      <div class="thumb-under">
+        <p class="title"><a title="Example Two" href="/videos/example-2">Example Two</a></p>
+        <div class="metadata">9 min - Category Two</div>
+      </div>
+    </div>
+    <div class="pagination">
+      <a class="no-page next-page" href="/new/2"></a>
+      <span class="last-page">5</span>
+    </div>
+  </body>
+</html>

--- a/tests/sites/test_anybunny.py
+++ b/tests/sites/test_anybunny.py
@@ -37,13 +37,13 @@ def test_list_populates_download_links(monkeypatch):
             'name': 'First Video Title',
             'url': 'http://anybunny.org/videos/first-video',
             'mode': 'anybunny.Playvid',
-            'icon': '//cdn.anybunny.org/thumb-first.jpg',
+            'icon': 'http://cdn.anybunny.org/thumb-first.jpg',
         },
         {
             'name': 'Second Video Title',
             'url': 'http://anybunny.org/videos/second-video',
             'mode': 'anybunny.Playvid',
-            'icon': '//cdn.anybunny.org/thumb-second.jpg',
+            'icon': 'http://cdn.anybunny.org/thumb-second.jpg',
         },
     ]
 

--- a/tests/sites/test_migrated_site_listings.py
+++ b/tests/sites/test_migrated_site_listings.py
@@ -1,0 +1,153 @@
+import pytest
+
+from tests.conftest import read_fixture
+
+from resources.lib.sites import (
+    xvideos,
+    xnxx,
+    spankbang,
+    eporner,
+    hqporner,
+    porntrex,
+    xhamster,
+    sxyprn,
+    whoreshub,
+    justporn,
+)
+
+
+SITE_FIXTURES = [
+    (
+        "xvideos",
+        xvideos,
+        "List",
+        ("https://www.xvideos.com/new/",),
+        {},
+        "sites/xvideos/listing.html",
+        True,
+    ),
+    (
+        "xnxx",
+        xnxx,
+        "List",
+        ("https://www.xnxx.com/todays-selection",),
+        {},
+        "sites/xnxx/listing.html",
+        True,
+    ),
+    (
+        "spankbang",
+        spankbang,
+        "List",
+        ("https://spankbang.party/new_videos/1/",),
+        {},
+        "sites/spankbang/listing.html",
+        True,
+    ),
+    (
+        "eporner",
+        eporner,
+        "List",
+        ("https://www.eporner.com/recent/",),
+        {},
+        "sites/eporner/listing.html",
+        True,
+    ),
+    (
+        "hqporner",
+        hqporner,
+        "HQLIST",
+        ("https://hqporner.com/hdporn/1",),
+        {},
+        "sites/hqporner/listing.html",
+        True,
+    ),
+    (
+        "porntrex",
+        porntrex,
+        "PTList",
+        ("https://www.porntrex.com/latest-updates/",),
+        {"page": 1},
+        "sites/porntrex/listing.html",
+        True,
+    ),
+    (
+        "xhamster",
+        xhamster,
+        "List",
+        ("https://xhamster.com/newest",),
+        {},
+        "sites/xhamster/listing.html",
+        True,
+    ),
+    (
+        "sxyprn",
+        sxyprn,
+        "List",
+        ("https://sxyprn.com/blog/all/0.html?fl=all&sm=latest",),
+        {},
+        "sites/sxyprn/listing.html",
+        True,
+    ),
+    (
+        "whoreshub",
+        whoreshub,
+        "List",
+        ("https://www.whoreshub.com/latest-updates/",),
+        {},
+        "sites/whoreshub/listing.html",
+        True,
+    ),
+    (
+        "justporn",
+        justporn,
+        "List",
+        ("https://justporn.xxx/video-list?lang=en&page=1",),
+        {},
+        "sites/justporn/listing.html",
+        True,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "site_name, module, func_name, func_args, func_kwargs, fixture_path, expect_pagination",
+    SITE_FIXTURES,
+)
+def test_migrated_site_listing_parses_videos(
+    monkeypatch,
+    site_name,
+    module,
+    func_name,
+    func_args,
+    func_kwargs,
+    fixture_path,
+    expect_pagination,
+):
+    html = read_fixture(fixture_path)
+    captured_videos = []
+    captured_dirs = []
+
+    def fake_get_html(*args, **kwargs):
+        return html
+
+    def capture_video(name, url, mode, iconimage, desc="", *_, **extra):
+        captured_videos.append({"title": name, "url": url, "thumb": iconimage, "extra": extra})
+
+    def capture_dir(name, url, mode, *args, **kwargs):
+        captured_dirs.append({"label": name, "url": url, "mode": mode})
+
+    monkeypatch.setattr(module.utils, "getHtml", fake_get_html)
+    monkeypatch.setattr(module.utils, "eod", lambda *a, **k: None)
+    monkeypatch.setattr(module.site, "add_download_link", capture_video)
+    monkeypatch.setattr(module.site, "add_dir", capture_dir)
+
+    getattr(module, func_name)(*func_args, **func_kwargs)
+
+    assert captured_videos, f"{site_name} fixture should yield at least one video"
+    assert captured_videos[0]["title"], "Video entries need a populated title"
+    assert captured_videos[0]["url"], "Video entries need a populated url"
+
+    if expect_pagination:
+        assert captured_dirs, f"{site_name} fixture should expose pagination"
+        assert captured_dirs[0]["url"], "Pagination entries require URLs"


### PR DESCRIPTION
## Summary
- add representative HTML fixtures for the migrated providers so soup-based parsers can be regression-tested
- add a parametrized test that runs each provider’s List routine against the stored HTML and validates the parsed output
- normalize pytest argv handling and fix the AnyBunny expectations to reflect the thumbnail normalization done by soup_videos_list

## Testing
- `pytest -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916443a0ab08327a28152c070684c0c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration for consistent argument handling.
  * Added HTML test fixtures for multiple video listing sites to improve parser coverage.
  * Enhanced site listing parser tests with parametrized validation across multiple platforms.
  * Updated test expectations for URL format consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->