### PR TITLE
Update Phase 8 outstanding sites list

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -248,9 +248,7 @@ All other sites not in previous phases.
 | freshporno | ⏳ Pending | |
 | fullporner | ⏳ Pending | |
 | fullxcinema | ⏳ Pending | |
-| hqporner | ⏳ Pending | |
 | justfullporn | ⏳ Pending | |
-| netflixporno | ✅ **COMPLETED** | Covered in Phase 3 migration (2025-11-11) |
 | porn4k | ⏳ Pending | |
 | porndish | ⏳ Pending | |
 | pornez | ⏳ Pending | |
@@ -265,6 +263,8 @@ All other sites not in previous phases.
 | xsharings | ⏳ Pending | |
 | xtheatre | ⏳ Pending | |
 | youcrazyx | ⏳ Pending | |
+
+> ℹ️ **Note**: Completed migrations (e.g., **hqporner** in Phase 1, **netflixporno** in Phase 3) are documented within their respective phases; Phase 8 only lists sites still awaiting work.
 
 **Target**: Complete by end of Phase 8
 


### PR DESCRIPTION
## Summary
- remove hqporner and netflixporno from the Phase 8 table so it only lists unfinished work
- add a clarifying note that completed sites are tracked in their respective phases rather than Phase 8

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bacfd90008327b70d0c8c959a2835)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project roadmap to clarify Phase 8 structure and consolidate migration documentation, ensuring completed phases are properly referenced and Phase 8 accurately reflects only pending work items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->