### PR TITLE
Replace bare except clauses in F4mProxy

### DIFF
--- a/script.video.F4mProxy/lib/F4mProxy.py
+++ b/script.video.F4mProxy/lib/F4mProxy.py
@@ -306,7 +306,7 @@ class MyHandler(BaseHTTPRequestHandler):
                     erange=int(file_size)-1
                 #Build range string
                 
-            except:
+            except Exception:
                 # Failure to build range string? Create a 0- range.
                 srange=0
                 erange=int(file_size-1);
@@ -330,16 +330,16 @@ class MyHandler(BaseHTTPRequestHandler):
         try:
             proxy = params['proxy'][0]#
             use_proxy_for_chunks =  params['use_proxy_for_chunks'][0]#
-        except: pass
+        except Exception: pass
         
         maxbitrate=0
         try:
             maxbitrate = int(params['maxbitrate'][0])
-        except: pass
+        except Exception: pass
         auth=None
         try:
             auth = params['auth'][0]
-        except: pass
+        except Exception: pass
 
         if auth=='None' and auth=='':
             auth=None
@@ -356,26 +356,26 @@ class MyHandler(BaseHTTPRequestHandler):
                 simpledownloader=True
             else:
                 simpledownloader=False
-        except: pass
+        except Exception: pass
         streamtype='HDS'
         try:
             streamtype =  params['streamtype'][0]#            
-        except: pass 
+        except Exception: pass 
         if streamtype=='None' and streamtype=='': streamtype='HDS'
 
         swf=None
         try:
             swf = params['swf'][0]
-        except: pass        
+        except Exception: pass        
         callbackpath=""
         try:
             callbackpath = params['callbackpath'][0]
-        except: pass        
+        except Exception: pass        
 
         callbackparam=None
         try:
             callbackparam = params['callbackparam'][0]
-        except: pass                
+        except Exception: pass                
         
      
         return (received_url,proxy,use_proxy_for_chunks,maxbitrate,simpledownloader,auth,streamtype,swf ,callbackpath, callbackparam )   
@@ -464,7 +464,7 @@ class f4mProxyHelper():
                 elif streamtype in ['HLSREDIR']:
                     listitem.setMimeType("application/vnd.apple.mpegurl");
                     listitem.setContentLookup(False) 
-            except: print 'error while setting setMimeType, so ignoring it '
+            except Exception: print 'error while setting setMimeType, so ignoring it '
                 
 
             if setResolved:
@@ -491,7 +491,7 @@ class f4mProxyHelper():
 
             print 'Job done'
             return played
-        except: return False
+        except Exception: return False
 
         
     def start_proxy(self,url,name,proxy=None,use_proxy_for_chunks=False, maxbitrate=0,simpleDownloader=False,auth=None,streamtype='HDS',swf=None, callbackpath="",callbackparam=""):

--- a/script.video.F4mProxy/lib/HLSDownloaderRetry.py
+++ b/script.video.F4mProxy/lib/HLSDownloaderRetry.py
@@ -54,7 +54,7 @@ callbackDRM=None
 try:
     from Crypto.Cipher import AES
     USEDec=1 ## 1==crypto 2==local, local pycrypto
-except:
+except Exception:
     print 'pycrypt not available using slow decryption'
     USEDec=3 ## 1==crypto 2==local, local pycrypto
 
@@ -122,7 +122,7 @@ class HLSDownloaderRetry():
             self.status='init done'
             self.url=url
             return True# disabled downloadInternal(self.url,None,self.maxbitrate,self.g_stopEvent , self.callbackpath,  self.callbackparam, testing=True)
-        except: 
+        except Exception: 
             traceback.print_exc()
             self.status='finished'
         return False
@@ -133,7 +133,7 @@ class HLSDownloaderRetry():
             self.status='download Starting'
 
             downloadInternal(self.url,dest_stream,self.maxbitrate,self.g_stopEvent , self.callbackpath,  self.callbackparam)
-        except: 
+        except Exception: 
             traceback.print_exc()
         print 'setting finished'
         self.status='finished'
@@ -176,7 +176,7 @@ def getUrl(url,timeout=15,returnres=False,stream =False):
         else:
             return req.text
 
-    except:
+    except Exception:
         print 'Error in getUrl'
         traceback.print_exc()
         raise 
@@ -223,7 +223,7 @@ def getUrlold(url,timeout=20, returnres=False):
 
         return data
 
-    except:
+    except Exception:
         print 'Error in getUrl'
         traceback.print_exc()
         return None
@@ -385,7 +385,7 @@ def handle_basic_m3u(url):
                                         callbackfilename= codeurlpath.split(os.path.sep)[-1].split('.')[0]
                                         callbackDRM = importlib.import_module(callbackfilename)
                                         print 'LSDRMCallBack imported'
-                                    except:
+                                    except Exception:
                                         traceback.print_exc()
                             
                         elif not codeurl.startswith('http'):
@@ -491,7 +491,7 @@ def downloadInternal(url,file,maxbitrate=0,stopEvent=None , callbackpath="",call
         utltext=res.text
         res.close()
         if testing: return True
-    except: traceback.print_exc()
+    except Exception: traceback.print_exc()
     print 'redirurl',redirurl
     if 'EXT-X-STREAM-INF' in utltext:
         try:
@@ -538,7 +538,7 @@ def downloadInternal(url,file,maxbitrate=0,stopEvent=None , callbackpath="",call
                 #choice = int(raw_input("Selection? "))
                 print 'choose %d'%choice
                 url = urlparse.urljoin(redirurl, variants[choice][0])
-        except: 
+        except Exception: 
             
             raise
 
@@ -590,7 +590,7 @@ def downloadInternal(url,file,maxbitrate=0,stopEvent=None , callbackpath="",call
                         callbackfilename= callbackpath.split(os.path.sep)[-1].split('.')[0]
                         callbackmodule = importlib.import_module(callbackfilename)
                         urlnew,cjnew=callbackmodule.f4mcallback(callbackparam, 1, inst, cookieJar , url, clientHeader)
-                    except: traceback.print_exc()
+                    except Exception: traceback.print_exc()
                     if urlnew and len(urlnew)>0 and urlnew.startswith('http'):
                         print 'got new url',url
                         url=urlnew
@@ -705,7 +705,7 @@ def downloadInternal(url,file,maxbitrate=0,stopEvent=None , callbackpath="",call
                             reconnect=True
                             fails+=1
                             break
-                    except: pass
+                    except Exception: pass
             
             if vod: return True
             if playedSomething == 1:
@@ -734,7 +734,7 @@ def downloadInternal(url,file,maxbitrate=0,stopEvent=None , callbackpath="",call
             if not playedSomething:
                 xbmc.sleep(3000+ (3000 if addsomewait else 0))
             
-    except:
+    except Exception:
         
         raise
 

--- a/script.video.F4mProxy/lib/HLSRedirector.py
+++ b/script.video.F4mProxy/lib/HLSRedirector.py
@@ -54,7 +54,7 @@ callbackDRM=None
 try:
     from Crypto.Cipher import AES
     USEDec=1 ## 1==crypto 2==local, local pycrypto
-except:
+except Exception:
     print 'pycrypt not available using slow decryption'
     USEDec=3 ## 1==crypto 2==local, local pycrypto
 
@@ -128,7 +128,7 @@ class HLSRedirector():
             self.status='init done'
             self.url=url
             return True# disabled downloadInternal(self.url,None,self.maxbitrate,self.g_stopEvent , self.callbackpath,  self.callbackparam, testing=True)
-        except: 
+        except Exception: 
             traceback.print_exc()
             self.status='finished'
         return False
@@ -139,7 +139,7 @@ class HLSRedirector():
             self.status='download Starting'
 
             downloadInternal(self.url,dest_stream,self.maxbitrate,self.g_stopEvent , self.callbackpath,  self.callbackparam)
-        except: 
+        except Exception: 
             traceback.print_exc()
         print 'setting finished'
         self.status='finished'
@@ -182,7 +182,7 @@ def getUrl(url,timeout=15,returnres=False,stream =False):
         else:
             return req.text
 
-    except:
+    except Exception:
         print 'Error in getUrl'
         traceback.print_exc()
         raise 
@@ -345,7 +345,7 @@ def downloadInternal(url,file,maxbitrate=0,stopEvent=None , callbackpath="",call
         utltext=res.text
         res.close()
         if testing: return True
-    except: traceback.print_exc()
+    except Exception: traceback.print_exc()
     print 'redirurl',redirurl
     if 'EXT-X-STREAM-INF' in utltext:
         try:
@@ -392,7 +392,7 @@ def downloadInternal(url,file,maxbitrate=0,stopEvent=None , callbackpath="",call
                 #choice = int(raw_input("Selection? "))
                 print 'choose %d'%choice
                 url = urlparse.urljoin(redirurl, variants[choice][0])
-        except: 
+        except Exception: 
             
             raise
 

--- a/script.video.F4mProxy/lib/TSDownloader.py
+++ b/script.video.F4mProxy/lib/TSDownloader.py
@@ -80,7 +80,7 @@ def getLastPTS(data,rpid,type="video"):
                     scramblecontrol = packet.read(2).uint
                     adapt = packet.read(2).uint
                     concounter = packet.read(4).uint
-                except:
+                except Exception:
                     #print 'error'
                     return None##print 'errpor'#adapt=-1
                 decodedpts=None
@@ -244,7 +244,7 @@ def getFirstPTSFrom(data,rpid, initpts,type="video" ):
                     scramblecontrol = packet.read(2).uint
                     adapt = packet.read(2).uint
                     concounter = packet.read(4).uint
-                except:
+                except Exception:
                     #print 'error'
                     return None##print 'errpor'#adapt=-1
                 decodedpts=None
@@ -399,7 +399,7 @@ class TSDownloader():
             response = openner.open(req)
 
             return response
-        except:
+        except Exception:
             #print 'Error in getUrl'
             traceback.print_exc()
         return None
@@ -431,7 +431,7 @@ class TSDownloader():
 
             return data
 
-        except:
+        except Exception:
             #print 'Error in getUrl'
             traceback.print_exc()
         return None
@@ -462,7 +462,7 @@ class TSDownloader():
             #return self.downloadInternal(testurl=True)
             
             #os.remove(self.outputfile)
-        except: 
+        except Exception: 
             traceback.print_exc()
         self.status='finished'
         return False
@@ -472,7 +472,7 @@ class TSDownloader():
         try:
             self.status='download Starting'
             self.downloadInternal(dest_stream=dest_stream)
-        except: 
+        except Exception: 
             traceback.print_exc()
         self.status='finished'
             
@@ -532,7 +532,7 @@ class TSDownloader():
                                 print 'test complete true'
                                 response.close()
                                 return True
-                        except:
+                        except Exception:
                             traceback.print_exc(file=sys.stdout)
                             print 'testurl',testurl,lost
                             if testurl and lost>10: 
@@ -565,7 +565,7 @@ class TSDownloader():
                                         
                                         try:
                                             firstpts,pos= getFirstPTSFrom(buf,fixpid,lastpts,defualtype)#
-                                        except:                                            
+                                        except Exception:                                            
                                             traceback.print_exc(file=sys.stdout)
                                             print 'getFirstPTSFrom error, using, last -1',# buf.encode("hex"), lastpts,
                                             firstpts,pos= getFirstPTSFrom(buf,fixpid,lastpts-1,defualtype)#
@@ -677,7 +677,7 @@ class TSDownloader():
                                 #    currentduration=0
                                 #if currentduration>10: currentduration=2
                                 ##print 'sleeping for',currentduration
-                            except: pass
+                            except Exception: pass
 
                     try:
                     
@@ -687,7 +687,7 @@ class TSDownloader():
                         response.close()
                         
                         print 'response closed'
-                    except:
+                    except Exception:
                         print 'close error'
                         traceback.print_exc(file=sys.stdout)
                     if wrotesomething==False  :
@@ -727,6 +727,6 @@ class TSDownloader():
                     return False
                 
 
-        except:
+        except Exception:
             traceback.print_exc()
             return

--- a/script.video.F4mProxy/lib/akhds.py
+++ b/script.video.F4mProxy/lib/akhds.py
@@ -41,7 +41,7 @@ try:
 
     USEDec=1 ## 1==crypto 2==local, local pycrypto
     print 'using pycrypt wooot woot'
-except:
+except Exception:
     print 'pycrypt not available trying other options'
     print traceback.print_exc()
     USEDec=3 ## 1==crypto 2==local, local pycrypto
@@ -52,7 +52,7 @@ except:
             AES=androidsslPy._load_crypto_libcrypto()
             USEDec=2 ## android
             print 'using android ssllib woot woot'
-        except: 
+        except Exception: 
             print traceback.print_exc()
             print 'android copy not available'    
             from f4mUtils import python_aes
@@ -223,7 +223,7 @@ def cleanup():
             print 'doing android cleanup'
             #AndroidCrypto.teardown()
             #print 'android cleanup'
-    except:
+    except Exception:
         pass
 
 

--- a/script.video.F4mProxy/lib/checkbad.py
+++ b/script.video.F4mProxy/lib/checkbad.py
@@ -20,7 +20,7 @@ def do_block_check(uninstall=False):
         return
     except SystemExit:
         sys.exit()
-    except:
+    except Exception:
         traceback.print_exc()
         pass
       

--- a/script.video.F4mProxy/lib/f4mDownloader.py
+++ b/script.video.F4mProxy/lib/f4mDownloader.py
@@ -28,7 +28,7 @@ import akhds
 try:
     addon_id = 'plugin.video.f4mTester' # yes its a wrong one but due to settings getting reset
     selfAddon = xbmcaddon.Addon(id=addon_id)
-except:
+except Exception:
     addon_id = 'script.video.F4mProxy' # yes its a wrong one but due to settings getting reset
     selfAddon = xbmcaddon.Addon(id=addon_id)
     
@@ -354,7 +354,7 @@ class F4MDownloader():
 
             return data
 
-        except:
+        except Exception:
             print 'Error in getUrl'
             traceback.print_exc()
             return None
@@ -419,7 +419,7 @@ class F4MDownloader():
             return self.preDownoload()
             
             #os.remove(self.outputfile)
-        except: 
+        except Exception: 
             traceback.print_exc()
             self.status='finished'
         return False
@@ -438,7 +438,7 @@ class F4MDownloader():
             print len(manifest)
             try:
                 print manifest
-            except: pass
+            except Exception: pass
             self.status='manifest done'
             #self.report_destination(filename)
             #dl = ReallyQuietDownloader(self.ydl, {'continuedl': True, 'quiet': True, 'noprogress':True})
@@ -478,7 +478,7 @@ class F4MDownloader():
                     if f.attrib.get('type', '')=='video' or vtype=='' :
                         formats.append([int(f.attrib.get('bitrate', -1)),f])
                 print 'format works',formats
-            except:
+            except Exception:
                 formats=[(int(0),f) for f in doc.findall(_add_ns('media'))]
             #print 'formats',formats
             
@@ -510,7 +510,7 @@ class F4MDownloader():
 
                 #self._write_flv_header(dest_stream, metadata)
                 #dest_stream.flush()
-            except: pass
+            except Exception: pass
         
             # Modified the-one 05082014
             # START
@@ -519,7 +519,7 @@ class F4MDownloader():
             # check for href attribute
             try:
                 mediaUrl=media.attrib['url']
-            except:
+            except Exception:
                 mediaUrl=media.attrib['href']
             # END
             
@@ -537,7 +537,7 @@ class F4MDownloader():
                 print len(sub_manifest)
                 try:
                     print sub_manifest
-                except: pass
+                except Exception: pass
                 self.status='sub manifest done'
                 F4Mversion =re.findall(version_fine, sub_manifest)[0]
                 doc = etree.fromstring(sub_manifest)
@@ -549,18 +549,18 @@ class F4MDownloader():
                 try:
                     self.metadata = base64.b64decode(media.find(_add_ns('metadata')).text)
                     print 'metadata stream read done'
-                except: pass
+                except Exception: pass
                 
                 try:
                     mediaUrl=media.attrib['url']
-                except:
+                except Exception:
                     mediaUrl=media.attrib['href']
             # END
             
             
             try:
                 bootStrapID = media.attrib['bootstrapInfoId']
-            except: bootStrapID='xx'
+            except Exception: bootStrapID='xx'
             #print 'mediaUrl',mediaUrl
             base_url = join(man_url,mediaUrl)#compat_urlparse.urljoin(man_url,media.attrib['url'])
             keybase_url=join(man_url,'key_')
@@ -584,7 +584,7 @@ class F4MDownloader():
             bootstrapURL1=''
             try:
                 bootstrapURL1=bootstrap.attrib['url']
-            except: pass
+            except Exception: pass
 
             bootstrapURL=''
             bootstrapData=None
@@ -633,7 +633,7 @@ class F4MDownloader():
             self.bootstrap, self.boot_info, self.fragments_list,self.total_frags=self.readBootStrapInfo(bootstrapURL,bootstrapData)
             self.init_done=True
             return True
-        except:
+        except Exception:
             traceback.print_exc()
         return False
 
@@ -741,11 +741,11 @@ class F4MDownloader():
         try:
             self.status='download Starting'            
             self.downloadInternal(self.url,dest_stream,segmentToStart,totalSegmentToSend)
-        except: 
+        except Exception: 
             traceback.print_exc()
         try:
             akhds.cleanup()                                    
-        except:pass
+        except Exception: pass
         self.status='finished'
             
     def downloadInternal(self,url,dest_stream ,segmentToStart=None,totalSegmentToSend=0):
@@ -803,7 +803,7 @@ class F4MDownloader():
                 try:    
                     if self.g_stopEvent.isSet():
                         return
-                except: pass
+                except Exception: pass
                 seg_i, frag_i=fragments_list[self.seqNumber]
                 self.seqNumber+=1
                 frameSent+=1
@@ -944,7 +944,7 @@ class F4MDownloader():
                                                     data=akhds.tagDecrypt(data,keyData)
                                                     
 
-                                                except:
+                                                except Exception:
                                                     print 'decryption error'
                                                     errors+=1
                                                     traceback.print_exc()
@@ -965,7 +965,7 @@ class F4MDownloader():
                                             #dest_stream.flush()
                                             #dest_stream.write(self.decryptData(data,keyData))
                                             #dest_stream.flush() 
-                                except:
+                                except Exception:
                                     print traceback.print_exc()
                                     self.g_stopEvent.set()     
                                     
@@ -996,7 +996,7 @@ class F4MDownloader():
                     total_frags=None
                     try:
                         bootstrap, boot_info, fragments_list,total_frags=self.readBootStrapInfo(self.bootstrapURL,None,updateMode=True,lastSegment=seg_i, lastFragement=frag_i)
-                    except: 
+                    except Exception: 
                         traceback.print_exc()
                         pass
                     if total_frags==None:
@@ -1004,7 +1004,7 @@ class F4MDownloader():
 
             del self.downloaded_bytes
             del self.frag_counter
-        except:
+        except Exception:
             traceback.print_exc()
             return
     def getBootStrapWithId (self,BSarray, id):
@@ -1014,7 +1014,7 @@ class F4MDownloader():
                 if bs.attrib['id']==id:
                     print 'gotcha'
                     return bs
-        except: pass
+        except Exception: pass
         return None
     
     def readBootStrapInfo(self,bootstrapUrl,bootStrapData, updateMode=False, lastFragement=None,lastSegment=None):
@@ -1027,7 +1027,7 @@ class F4MDownloader():
                     if self.g_stopEvent.isSet():
                         print 'event is set. returning'
                         return
-                except: pass
+                except Exception: pass
 
                 if bootStrapData==None:
                     bootStrapData =self.getUrl(bootstrapUrl)
@@ -1055,7 +1055,7 @@ class F4MDownloader():
                     xbmc.sleep(2000)
                     continue
                 return bootstrap, boot_info, fragments_list,total_frags
-        except:
+        except Exception:
             traceback.print_exc()
     
 

--- a/script.video.F4mProxy/lib/hlsDownloader.py
+++ b/script.video.F4mProxy/lib/hlsDownloader.py
@@ -53,7 +53,7 @@ callbackDRM=None
 try:
     from Crypto.Cipher import AES
     USEDec=1 ## 1==crypto 2==local, local pycrypto
-except:
+except Exception:
     print 'pycrypt not available using slow decryption'
     USEDec=3 ## 1==crypto 2==local, local pycrypto
 
@@ -119,7 +119,7 @@ class HLSDownloader():
             self.status='init done'
             self.url=url
             return True# disabled for time being#downloadInternal(self.url,None,self.maxbitrate,self.g_stopEvent, testing=True)
-        except: 
+        except Exception: 
             traceback.print_exc()
         self.status='finished'
         return False
@@ -128,7 +128,7 @@ class HLSDownloader():
         try:
             self.status='download Starting'
             downloadInternal(self.url,dest_stream,self.maxbitrate,self.g_stopEvent)
-        except: 
+        except Exception: 
             traceback.print_exc()
         self.status='finished'
 
@@ -163,7 +163,7 @@ def getUrl(url,timeout=15,returnres=False,stream=False):
         else:
             return req.text
 
-    except:
+    except Exception:
         print 'Error in getUrl'
         traceback.print_exc()
         return None
@@ -209,7 +209,7 @@ def getUrlold(url,timeout=20, returnres=False):
 
         return data
 
-    except:
+    except Exception:
         print 'Error in getUrl'
         traceback.print_exc()
         return None
@@ -413,7 +413,7 @@ def handle_basic_m3u(url):
                                         callbackfilename= codeurlpath.split(os.path.sep)[-1].split('.')[0]
                                         callbackDRM = importlib.import_module(callbackfilename)
                                         print 'LSDRMCallBack imported'
-                                    except:
+                                    except Exception:
                                         traceback.print_exc()
                             
                         
@@ -509,7 +509,7 @@ def downloadInternal(url,file,maxbitrate=0,stopEvent=None, testing=False):
             redirurl=res.url
         res.close()
         if testing: return True
-    except: traceback.print_exc()
+    except Exception: traceback.print_exc()
     print 'redirurl',redirurl
     
     
@@ -568,7 +568,7 @@ def downloadInternal(url,file,maxbitrate=0,stopEvent=None, testing=False):
     #if ':7777' in url:
     #    try:
     #        glsession=re.compile(':7777\/.*?m3u8.*?session=(.*?)&').findall(url)[0]
-    #    except: 
+    #    except Exception: 
     #        pass
 
     try:
@@ -650,7 +650,7 @@ def downloadInternal(url,file,maxbitrate=0,stopEvent=None, testing=False):
                         last_seq = seq
                         changed = 1
                         playedSomething=True
-                    except: pass
+                    except Exception: pass
             
             '''if changed == 1:
                 # initial minimum reload delay
@@ -670,7 +670,7 @@ def downloadInternal(url,file,maxbitrate=0,stopEvent=None, testing=False):
             return
             if not playedSomething:
                 xbmc.sleep(2000+ (3000 if addsomewait else 0))
-    except:
+    except Exception:
         control[0] = 'stop'
         raise
 

--- a/script.video.F4mProxy/lib/interalSimpleDownloader.py
+++ b/script.video.F4mProxy/lib/interalSimpleDownloader.py
@@ -67,7 +67,7 @@ class interalSimpleDownloader():
             response = openner.open(req)
 
             return response
-        except:
+        except Exception:
             print 'Error in getUrl'
             traceback.print_exc()
         return None
@@ -99,7 +99,7 @@ class interalSimpleDownloader():
 
             return data
 
-        except:
+        except Exception:
             print 'Error in getUrl'
             traceback.print_exc()
         return None
@@ -129,7 +129,7 @@ class interalSimpleDownloader():
             return True
             
             #os.remove(self.outputfile)
-        except: 
+        except Exception: 
             traceback.print_exc()
             self.status='finished'
         return False
@@ -139,7 +139,7 @@ class interalSimpleDownloader():
         try:
             self.status='download Starting'
             self.downloadInternal(self.url,dest_stream)
-        except: 
+        except Exception: 
             traceback.print_exc()
         self.status='finished'
             
@@ -171,7 +171,7 @@ class interalSimpleDownloader():
                                     print 'maxbitrate',self.maxbitRate
                                     ec=EdgeClass(buf,url,'http://www.en.beinsports.net/i/PerformConsole_BEIN/player/bin-release/PerformConsole.swf',sendToken=False)                                
                                     ec.switchStream(self.maxbitRate,"DOWN")
-                        except:
+                        except Exception:
                             traceback.print_exc()
                     response.close()
                     fileout.close()
@@ -189,7 +189,7 @@ class interalSimpleDownloader():
                     fileout.close()
                 
 
-        except:
+        except Exception:
             traceback.print_exc()
             return
 class EdgeClass():


### PR DESCRIPTION
## Summary
- replace bare `except:` blocks in F4mProxy helper modules with `except Exception:`
- avoid swallowing interrupts or system-exiting exceptions while preserving existing error handling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921f42c8c448327b56167da68210c92)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling across the F4mProxy library by replacing overly broad exception handling with more specific exception types. This prevents accidental suppression of critical system signals while maintaining existing error recovery behavior and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->