### PR TITLE
Add tests for BeautifulSoup site parsers

### DIFF
--- a/tests/fixtures/netflav/genres.html
+++ b/tests/fixtures/netflav/genres.html
@@ -1,0 +1,19 @@
+<html>
+  <body>
+    <div class="genre-section">
+      <div class="container_header_title_large">Popular Genres</div>
+      <div>
+        <a href="/all?genre=romance&page=1"><div>Romance</div></a>
+        <a href="/all?genre=action&page=1"><div>Action</div></a>
+        <a href="/all?genre=comedy&page=1"><div>Comedy</div></a>
+      </div>
+    </div>
+    <div class="genre-section">
+      <div class="container_header_title_large">Sub Genres</div>
+      <div>
+        <a href="/all?genre=drama&page=1"><div>Drama</div></a>
+        <a href="/all?genre=horror&page=1"><div>Horror</div></a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/netflav/listing.html
+++ b/tests/fixtures/netflav/listing.html
@@ -1,0 +1,31 @@
+<html>
+  <head></head>
+  <body>
+    <script id="__NEXT_DATA__" type="application/json">
+      {
+        "props": {
+          "initialState": {
+            "all": {
+              "page": 1,
+              "pages": 3,
+              "docs": [
+                {
+                  "title_en": "Sample Title One",
+                  "preview": "https://netflav.com/thumbs/one.jpg",
+                  "sourceDate": "2024-11-15T00:00:00",
+                  "videoId": "abc123"
+                },
+                {
+                  "title_en": "Sample Title Two",
+                  "preview": "https://netflav.com/thumbs/two.jpg",
+                  "createdAt": "2024-11-10T00:00:00",
+                  "videoId": "def456"
+                }
+              ]
+            }
+          }
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/tests/fixtures/sites/foxnxx/listing.html
+++ b/tests/fixtures/sites/foxnxx/listing.html
@@ -1,0 +1,22 @@
+<html>
+  <body>
+    <div class="thumb">
+      <a href="https://foxnxx.com/video/video-one" title="First Video">
+        <img data-src="https://img.cdn/one.jpg" alt="First Video thumb" />
+        <div class="timer">10:11</div>
+      </a>
+    </div>
+    <div class="thumb">
+      <a href="https://foxnxx.com/video/video-two" title="Video Two Title">
+        <img src="https://img.cdn/two.jpg" alt="Second Video thumb" />
+        <span class="timer">05:00</span>
+        Video Two Title
+      </a>
+    </div>
+    <ul class="pagination">
+      <li class="active"><a href="/page/1.html">1</a></li>
+      <li><a href="https://foxnxx.com/page/2.html">2</a></li>
+      <li><a href="https://foxnxx.com/page/5.html">5</a></li>
+    </ul>
+  </body>
+</html>

--- a/tests/sites/test_foxnxx.py
+++ b/tests/sites/test_foxnxx.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_ROOT = ROOT / "plugin.video.cumination"
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
+
+from resources.lib.sites import foxnxx
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "sites" / "foxnxx"
+
+
+def load_fixture(name: str) -> str:
+    return (FIXTURE_DIR / name).read_text(encoding="utf-8")
+
+
+def test_list_parses_videos_and_pagination(monkeypatch):
+    html = load_fixture("listing.html")
+
+    downloads = []
+    dirs = []
+
+    def fake_add_download_link(name, url, mode, iconimage, desc="", **kwargs):
+        downloads.append({
+            "name": name,
+            "url": url,
+            "mode": mode,
+            "icon": iconimage,
+            "desc": desc,
+            "duration": kwargs.get("duration"),
+            "context": kwargs.get("contextm"),
+        })
+
+    def fake_add_dir(name, url, mode, iconimage=None, desc="", **kwargs):
+        dirs.append({
+            "name": name,
+            "url": url,
+            "mode": mode,
+        })
+
+    monkeypatch.setattr(foxnxx.utils, "getHtml", lambda *a, **k: html)
+    monkeypatch.setattr(foxnxx.utils, "eod", lambda *a, **k: None)
+    monkeypatch.setattr(foxnxx.site, "add_download_link", fake_add_download_link)
+    monkeypatch.setattr(foxnxx.site, "add_dir", fake_add_dir)
+
+    foxnxx.List("https://foxnxx.com/new")
+
+    assert len(downloads) == 2
+    assert downloads[0]["name"] == "First Video"
+    assert "video-one" in downloads[0]["url"]
+    assert downloads[0]["duration"] == "10:11"
+    assert downloads[0]["context"]
+
+    assert downloads[1]["name"] == "Video Two Title"
+    assert "video-two" in downloads[1]["url"]
+    assert downloads[1]["duration"] == "05:00"
+
+    assert dirs, "Expected pagination entry"
+    next_dir = dirs[0]
+    assert "Next Page (2)" in next_dir["name"]
+    assert next_dir["url"].endswith("/page/2.html")

--- a/tests/sites/test_netflav.py
+++ b/tests/sites/test_netflav.py
@@ -1,0 +1,99 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_ROOT = ROOT / "plugin.video.cumination"
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
+
+from resources.lib.sites import netflav
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "netflav"
+
+
+def load_fixture(name: str) -> str:
+    return (FIXTURE_DIR / name).read_text(encoding="utf-8")
+
+
+def test_list_parses_videos_and_next_page(monkeypatch):
+    html = load_fixture("listing.html")
+
+    downloads = []
+    dirs = []
+
+    monkeypatch.setattr(netflav.utils, "getHtml", lambda *a, **k: html)
+    monkeypatch.setattr(netflav.utils, "eod", lambda *a, **k: None)
+
+    def fake_add_download_link(name, url, mode, iconimage, desc="", **kwargs):
+        downloads.append({
+            "name": name,
+            "url": url,
+            "icon": iconimage,
+            "plot": desc,
+            "context": kwargs.get("contextm"),
+        })
+
+    def fake_add_dir(name, url, mode, iconimage=None, desc="", **kwargs):
+        dirs.append({
+            "name": name,
+            "url": url,
+            "mode": mode,
+            "section": kwargs.get("section"),
+        })
+
+    monkeypatch.setattr(netflav.site, "add_download_link", fake_add_download_link)
+    monkeypatch.setattr(netflav.site, "add_dir", fake_add_dir)
+
+    netflav.List("https://netflav.com/all?page=1", section="all")
+
+    assert len(downloads) == 2
+    assert downloads[0]["name"] == "Sample Title One"
+    assert downloads[0]["url"].endswith("video?id=abc123")
+    assert "2024-11-15" in downloads[0]["plot"]
+    assert downloads[0]["context"]
+
+    assert downloads[1]["name"] == "Sample Title Two"
+    assert downloads[1]["url"].endswith("video?id=def456")
+    assert "2024-11-10" in downloads[1]["plot"]
+
+    next_pages = [d for d in dirs if "Next Page" in d["name"]]
+    assert next_pages
+    assert next_pages[0]["url"].endswith("page=2")
+    assert next_pages[0]["section"] == "all"
+
+
+def test_genres_groups_and_sorts(monkeypatch):
+    html = load_fixture("genres.html")
+
+    dirs = []
+
+    monkeypatch.setattr(netflav.utils, "getHtml", lambda *a, **k: html)
+    monkeypatch.setattr(netflav.utils, "eod", lambda *a, **k: None)
+
+    def fake_add_dir(name, url, mode, iconimage=None, desc="", **kwargs):
+        dirs.append({
+            "name": name,
+            "url": url,
+            "mode": mode,
+        })
+
+    monkeypatch.setattr(netflav.site, "add_dir", fake_add_dir)
+
+    netflav.Genres("https://netflav.com/genre")
+
+    assert len(dirs) == 5
+    names = [d["name"] for d in dirs]
+    # Should be sorted within each header
+    assert names[:3] == [
+        "Popular Genres - Action",
+        "Popular Genres - Comedy",
+        "Popular Genres - Romance",
+    ]
+    assert names[3:] == [
+        "Sub Genres - Drama",
+        "Sub Genres - Horror",
+    ]
+
+    for dir_item in dirs:
+        assert dir_item["url"].startswith("https://netflav.com/")
+        assert "page=1" in dir_item["url"]


### PR DESCRIPTION
## Summary
- add foxnxx listing fixture and test covering BeautifulSoup-based parsing and pagination
- add netflav listing and genres fixtures with tests for video extraction, pagination, and category sorting

## Testing
- pytest tests/sites/test_foxnxx.py tests/sites/test_netflav.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922041dbbe88327bde458be2fbba95d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for site integration functionality, validating video listing extraction, pagination handling, genre categorization with proper sorting, and metadata parsing across multiple supported sites.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->