### PR TITLE
Improve playback extraction for Aylo sites and Motherless

### DIFF
--- a/plugin.video.cumination/resources/lib/sites/motherless.py
+++ b/plugin.video.cumination/resources/lib/sites/motherless.py
@@ -67,12 +67,13 @@ def List(url):
             elif not video_url.startswith('http'):
                 video_url = site.url + video_url
 
-            # Normalise URL to drop query params to prevent duplicates
+            # Normalize URL to drop query params to prevent duplicates
             parsed = urllib_parse.urlsplit(video_url)
             canonical_url = urllib_parse.urlunsplit((parsed.scheme, parsed.netloc, parsed.path, '', ''))
             if canonical_url in seen:
                 continue
             seen.add(canonical_url)
+            video_url = canonical_url
 
             # Extract title from the caption link
             title_link = item.select_one('a.caption.title')
@@ -111,7 +112,6 @@ def List(url):
         next_url = utils.safe_get_attr(next_link, 'href')
         if next_url:
             # Extract page number for display
-            import re
             page_match = re.search(r'page=(\d+)', next_url)
             page_num = page_match.group(1) if page_match else ''
 
@@ -131,7 +131,6 @@ def Search(url, keyword=None):
     if not keyword:
         site.search_dir(url, 'Search')
     else:
-        from six.moves import urllib_parse
         title = urllib_parse.quote_plus(keyword)
         searchUrl = searchUrl + title
         List(searchUrl)
@@ -201,7 +200,7 @@ def Playvid(url, name, download=None):
     src = _extract_best_source(html)
     if src:
         # Use the page URL as referer for CDN checks
-        vp.play_from_direct_link(f"{src}|Referer={url}")
+        vp.play_from_direct_link("{0}|Referer={1}".format(src, url))
     else:
         vp.play_from_link_to_resolve(url)
 

--- a/plugin.video.cumination/resources/lib/sites/redtube.py
+++ b/plugin.video.cumination/resources/lib/sites/redtube.py
@@ -184,7 +184,7 @@ def Playvid(url, name, download=None):
     src = _extract_best_source(html)
     if src:
         # Use the page URL as referer to satisfy CDN checks
-        vp.play_from_direct_link(f"{src}|Referer={url}")
+        vp.play_from_direct_link("{0}|Referer={1}".format(src, url))
     else:
         vp.play_from_link_to_resolve(url)
 
@@ -206,7 +206,7 @@ def _extract_best_source(html):
 
     if not candidates:
         # Fallback: look for quality/url pairs used by Aylo inline JSON
-        for quality, src in re.findall(r'"(?:quality|label)"\s*:\s*"?(\d{3,4})p?"?[^\n]*?"(?:videoUrl|src|url)"\s*:\s*"([^"]+)', html, re.IGNORECASE):
+        for quality, src in re.findall(r'"(?:quality|label)"\s*:\s*"?(\d{3,4})p?"?.*?"(?:videoUrl|src|url)"\s*:\s*"([^"]+)', html, re.IGNORECASE | re.DOTALL):
             candidates.append((quality, src.replace('\\/', '/')))
 
     if not candidates:

--- a/plugin.video.cumination/resources/lib/sites/tube8.py
+++ b/plugin.video.cumination/resources/lib/sites/tube8.py
@@ -188,7 +188,7 @@ def Playvid(url, name, download=None):
     src = _extract_best_source(html)
     if src:
         # Use the page URL as referer to satisfy CDN checks
-        vp.play_from_direct_link(f"{src}|Referer={url}")
+        vp.play_from_direct_link("{0}|Referer={1}".format(src, url))
     else:
         vp.play_from_link_to_resolve(url)
 
@@ -210,7 +210,7 @@ def _extract_best_source(html):
 
     if not candidates:
         # Fallback: look for quality/url pairs used by Aylo inline JSON
-        for quality, src in re.findall(r'"(?:quality|label)"\s*:\s*"?(\d{3,4})p?"?[^\n]*?"(?:videoUrl|src|url)"\s*:\s*"([^"]+)', html, re.IGNORECASE):
+        for quality, src in re.findall(r'"(?:quality|label)"\s*:\s*"?(\d{3,4})p?"?.*?"(?:videoUrl|src|url)"\s*:\s*"([^"]+)', html, re.IGNORECASE | re.DOTALL):
             candidates.append((quality, src.replace('\\/', '/')))
 
     if not candidates:

--- a/plugin.video.cumination/resources/lib/sites/youjizz.py
+++ b/plugin.video.cumination/resources/lib/sites/youjizz.py
@@ -206,7 +206,7 @@ def Playvid(url, name, download=None):
     src = _extract_best_source(html)
     if src:
         # Use the page URL as referer to satisfy CDN checks
-        vp.play_from_direct_link(f"{src}|Referer={url}")
+        vp.play_from_direct_link("{0}|Referer={1}".format(src, url))
     else:
         vp.play_from_link_to_resolve(url)
 
@@ -228,7 +228,7 @@ def _extract_best_source(html):
 
     if not candidates:
         # Fallback: look for quality/url pairs used by Aylo inline JSON
-        for quality, src in re.findall(r'"(?:quality|label)"\s*:\s*"?(\d{3,4})p?"?[^\n]*?"(?:videoUrl|src|url)"\s*:\s*"([^"]+)', html, re.IGNORECASE):
+        for quality, src in re.findall(r'"(?:quality|label)"\s*:\s*"?(\d{3,4})p?"?.*?"(?:videoUrl|src|url)"\s*:\s*"([^"]+)', html, re.IGNORECASE | re.DOTALL):
             candidates.append((quality, src.replace('\\/', '/')))
 
     if not candidates:

--- a/plugin.video.cumination/resources/lib/sites/youporn.py
+++ b/plugin.video.cumination/resources/lib/sites/youporn.py
@@ -190,7 +190,7 @@ def Playvid(url, name, download=None):
     src = _extract_best_source(html)
     if src:
         # Use the actual page as referer to satisfy Aylo CDN checks
-        vp.play_from_direct_link(f"{src}|Referer={url}")
+        vp.play_from_direct_link("{0}|Referer={1}".format(src, url))
     else:
         vp.play_from_link_to_resolve(url)
 
@@ -213,7 +213,7 @@ def _extract_best_source(html):
 
     if not candidates:
         # Fallback: look for quality/url pairs used by Aylo inline JSON
-        for quality, src in re.findall(r'"(?:quality|label)"\s*:\s*"?(\d{3,4})p?"?[^\n]*?"(?:videoUrl|src|url)"\s*:\s*"([^"]+)', html, re.IGNORECASE):
+        for quality, src in re.findall(r'"(?:quality|label)"\s*:\s*"?(\d{3,4})p?"?.*?"(?:videoUrl|src|url)"\s*:\s*"([^"]+)', html, re.IGNORECASE | re.DOTALL):
             candidates.append((quality, src.replace('\\/', '/')))
 
     if not candidates:


### PR DESCRIPTION
## Summary
- send video requests for YouPorn, YouJizz, Tube8, and RedTube using the page URL as the referer
- broaden source extraction across Aylo sites to pick up additional mp4/m3u8 links
- normalise Motherless video URLs to avoid duplicate entries and add extra direct source fallback

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69296307d6a48327add288e9d6a21a8e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback reliability by expanding source discovery with multiple fallback strategies to find mp4/m3u8 and inline JSON sources.
  * Updated Referer handling to use the actual page URL for direct-link playback, improving CDN compatibility.
  * Normalized video URLs to strip extraneous query data for more accurate duplicate detection and storage.
  * Strengthened overall fallback flow to reduce failed play attempts when primary sources are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->