### PR TITLE
Log TabooTube fetch failures

### DIFF
--- a/plugin.video.cumination/resources/lib/sites/tabootube.py
+++ b/plugin.video.cumination/resources/lib/sites/tabootube.py
@@ -18,7 +18,7 @@
 
 import re
 
-from kodi_six import xbmc
+import xbmc
 from six.moves import urllib_parse
 
 from resources.lib import utils
@@ -41,6 +41,13 @@ def Main(url):
 def List(url, page=1):
     try:
         listhtml = utils.getHtml(url, '')
+        if not listhtml:
+            utils.kodilog(
+                f"TabooTube: Got empty response for list page {page} at {url}",
+                xbmc.LOGWARNING,
+            )
+            utils.eod()
+            return
     except Exception as exc:
         utils.kodilog(f"TabooTube: Failed to fetch list page {page}: {exc}", xbmc.LOGERROR)
         raise
@@ -92,6 +99,10 @@ def Playvid(url, name, download=None):
 def Categories(url):
     try:
         cathtml = utils.getHtml(url, '')
+        if not cathtml:
+            utils.kodilog(f"TabooTube: Got empty response for categories at {url}", xbmc.LOGWARNING)
+            utils.eod()
+            return
     except Exception as exc:
         utils.kodilog(f"TabooTube: Failed to fetch categories: {exc}", xbmc.LOGERROR)
         raise
@@ -107,6 +118,10 @@ def Categories(url):
 def Tags(url):
     try:
         taghtml = utils.getHtml(url, '')
+        if not taghtml:
+            utils.kodilog(f"TabooTube: Got empty response for tags at {url}", xbmc.LOGWARNING)
+            utils.eod()
+            return
     except Exception as exc:
         utils.kodilog(f"TabooTube: Failed to fetch tags: {exc}", xbmc.LOGERROR)
         raise

--- a/tests/sites/test_tabootube_exceptions.py
+++ b/tests/sites/test_tabootube_exceptions.py
@@ -7,6 +7,10 @@ def _raise_get_html(*_, **__):
     raise ValueError("boom")
 
 
+def _empty_get_html(*_, **__):
+    return ""
+
+
 def test_tabootube_list_logs_and_raises(monkeypatch):
     messages = []
 
@@ -33,3 +37,74 @@ def test_tabootube_categories_logs_and_raises(monkeypatch):
     assert messages == [
         ("TabooTube: Failed to fetch categories: boom", tabootube.xbmc.LOGERROR),
     ]
+
+
+def test_tabootube_tags_logs_and_raises(monkeypatch):
+    messages = []
+
+    monkeypatch.setattr(tabootube.utils, "getHtml", _raise_get_html)
+    monkeypatch.setattr(tabootube.utils, "kodilog", lambda msg, level=None: messages.append((msg, level)))
+
+    with pytest.raises(ValueError):
+        tabootube.Tags("https://example.com/tags")
+
+    assert messages == [
+        ("TabooTube: Failed to fetch tags: boom", tabootube.xbmc.LOGERROR),
+    ]
+
+
+def test_tabootube_list_logs_empty_response(monkeypatch):
+    messages = []
+    eod_calls = []
+
+    monkeypatch.setattr(tabootube.utils, "getHtml", _empty_get_html)
+    monkeypatch.setattr(tabootube.utils, "kodilog", lambda msg, level=None: messages.append((msg, level)))
+    monkeypatch.setattr(tabootube.utils, "eod", lambda: eod_calls.append("eod"))
+
+    assert tabootube.List("https://example.com", page=2) is None
+
+    assert messages == [
+        (
+            "TabooTube: Got empty response for list page 2 at https://example.com",
+            tabootube.xbmc.LOGWARNING,
+        ),
+    ]
+    assert eod_calls == ["eod"]
+
+
+def test_tabootube_categories_logs_empty_response(monkeypatch):
+    messages = []
+    eod_calls = []
+
+    monkeypatch.setattr(tabootube.utils, "getHtml", _empty_get_html)
+    monkeypatch.setattr(tabootube.utils, "kodilog", lambda msg, level=None: messages.append((msg, level)))
+    monkeypatch.setattr(tabootube.utils, "eod", lambda: eod_calls.append("eod"))
+
+    assert tabootube.Categories("https://example.com/categories") is None
+
+    assert messages == [
+        (
+            "TabooTube: Got empty response for categories at https://example.com/categories",
+            tabootube.xbmc.LOGWARNING,
+        ),
+    ]
+    assert eod_calls == ["eod"]
+
+
+def test_tabootube_tags_logs_empty_response(monkeypatch):
+    messages = []
+    eod_calls = []
+
+    monkeypatch.setattr(tabootube.utils, "getHtml", _empty_get_html)
+    monkeypatch.setattr(tabootube.utils, "kodilog", lambda msg, level=None: messages.append((msg, level)))
+    monkeypatch.setattr(tabootube.utils, "eod", lambda: eod_calls.append("eod"))
+
+    assert tabootube.Tags("https://example.com/tags") is None
+
+    assert messages == [
+        (
+            "TabooTube: Got empty response for tags at https://example.com/tags",
+            tabootube.xbmc.LOGWARNING,
+        ),
+    ]
+    assert eod_calls == ["eod"]


### PR DESCRIPTION
## Summary
- log TabooTube listing, category, and tag fetch failures instead of silently returning
- add unit tests that verify TabooTube exception paths log through utils.kodilog
- re-run ruff checks on plugin modules and tests

## Testing
- python -m ruff check plugin.video.cumination/resources/lib tests
- python -m pytest tests/sites/test_tabootube_exceptions.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693227ba4a7883278578a20551e6796e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging for TabooTube failures, now providing detailed error messages to help diagnose issues.

* **New Features**
  * TabooTube is now configured as the default source.

* **Tests**
  * Added tests to verify error handling and logging behavior for TabooTube operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->