### PR TITLE
Migrate animeidhentai scraper to BeautifulSoup

### DIFF
--- a/tests/fixtures/sites/animeidhentai/genres.html
+++ b/tests/fixtures/sites/animeidhentai/genres.html
@@ -1,0 +1,16 @@
+<html>
+<body>
+<section class="genres">
+  <article class="anime xs">
+    <img src="https://cdn.animeid/action.jpg" />
+    <a class="link-co" href="https://animeidhentai.com/genre/action/">Action</a>
+    <span class="fwb">12</span>
+  </article>
+  <article class="anime xs">
+    <img data-src="https://cdn.animeid/romance.jpg" />
+    <a class="link-co" href="https://animeidhentai.com/genre/romance/">Romance</a>
+    <span class="fwb">8</span>
+  </article>
+</section>
+</body>
+</html>

--- a/tests/fixtures/sites/animeidhentai/list.html
+++ b/tests/fixtures/sites/animeidhentai/list.html
@@ -1,0 +1,22 @@
+<html>
+<body>
+<section class="content">
+  <article class="anime xs">
+    <a class="thumb" href="https://animeidhentai.com/video-one/">
+      <img loading="lazy" data-src="https://cdn.animeid/thumb1.jpg" />
+    </a>
+    <a class="link-co" href="https://animeidhentai.com/video-one/">Video One Uncensored</a>
+    <div class="mgr"><span>HD</span><span>2023</span></div>
+    <div class="description dn"><p>First plot goes here.</p></div>
+  </article>
+  <article class="anime xs">
+    <a class="link-co" href="https://animeidhentai.com/video-two/">Video Two</a>
+    <img loading="lazy" src="https://cdn.animeid/thumb2.jpg" />
+    <div class="mgr"><span>1080p</span><span>2020</span></div>
+    <div class="description dn">Second plot goes here.</div>
+  </article>
+</section>
+<link rel="next" href="https://animeidhentai.com/page/2/" />
+<a class="next page-numbers" href="https://animeidhentai.com/page/2/">Next Page</a>
+</body>
+</html>

--- a/tests/fixtures/sites/animeidhentai/play_main.html
+++ b/tests/fixtures/sites/animeidhentai/play_main.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+<div id="player">
+  <iframe src="https://nhplayer.com/embed/abc123"></iframe>
+</div>
+</body>
+</html>

--- a/tests/fixtures/sites/animeidhentai/play_nhplayer.html
+++ b/tests/fixtures/sites/animeidhentai/play_nhplayer.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+<ul class="sources">
+  <li data-id="/videos/abc123.m3u8">Server 1</li>
+</ul>
+</body>
+</html>

--- a/tests/fixtures/sites/animeidhentai/play_source.html
+++ b/tests/fixtures/sites/animeidhentai/play_source.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<script>
+var fileData = {file: "https://cdn.example.com/video.m3u8"};
+file: "https://cdn.example.com/video.m3u8";
+</script>
+</body>
+</html>

--- a/tests/fixtures/sites/animeidhentai/years.html
+++ b/tests/fixtures/sites/animeidhentai/years.html
@@ -1,0 +1,9 @@
+<html>
+<body>
+<form>
+  <input type="radio" name="years" id="year-2024" value="2024" data-name="2024" />
+  <input type="radio" name="years" id="year-2022" value="2022" data-name="2022" />
+  <input type="radio" name="years" id="year-2020" value="2020" data-name="2020" />
+</form>
+</body>
+</html>

--- a/tests/sites/test_animeidhentai.py
+++ b/tests/sites/test_animeidhentai.py
@@ -1,0 +1,142 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_ROOT = ROOT / "plugin.video.cumination"
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
+
+if len(sys.argv) < 3 or not str(sys.argv[1]).isdigit():
+    sys.argv = ['plugin.video.cumination', '1', '']
+
+MODULE_PATH = PLUGIN_ROOT / "resources" / "lib" / "sites" / "animeidhentai.py"
+spec = importlib.util.spec_from_file_location("animeidhentai", MODULE_PATH)
+animeidhentai = importlib.util.module_from_spec(spec)
+if spec and spec.loader:
+    spec.loader.exec_module(animeidhentai)
+    sys.modules["animeidhentai"] = animeidhentai
+
+
+FIXTURE_BASE = Path(__file__).resolve().parents[1] / "fixtures" / "sites" / "animeidhentai"
+
+def load_fixture(name: str) -> str:
+    return (FIXTURE_BASE / name).read_text(encoding="utf-8")
+
+
+def test_list_uses_beautifulsoup(monkeypatch):
+    html = load_fixture("list.html")
+    downloads = []
+    dirs = []
+
+    monkeypatch.setattr(animeidhentai.utils, "getHtml", lambda *a, **k: html)
+    monkeypatch.setattr(animeidhentai.utils, "eod", lambda: None)
+
+    def record_download(name, url, mode, thumb, desc="", **kwargs):
+        downloads.append({
+            "name": name,
+            "url": url,
+            "mode": mode,
+            "thumb": thumb,
+            "desc": desc,
+            "quality": kwargs.get("quality"),
+        })
+
+    monkeypatch.setattr(animeidhentai.site, "add_download_link", record_download)
+    monkeypatch.setattr(animeidhentai.site, "add_dir", lambda *a, **k: dirs.append(a))
+
+    animeidhentai.animeidhentai_list("https://animeidhentai.com/")
+
+    assert [d["name"] for d in downloads] == [
+        "Video One [COLOR hotpink][I]Uncensored[/I][/COLOR] [COLOR blue](2023)[/COLOR]",
+        "Video Two [COLOR blue](2020)[/COLOR]",
+    ]
+    assert downloads[0]["quality"] == "HD"
+    assert downloads[1]["quality"] == "FHD"
+    assert downloads[0]["desc"].startswith("First plot")
+
+    next_dirs = [entry for entry in dirs if entry[2] == "animeidhentai_list"]
+    assert next_dirs and "Next Page" in next_dirs[0][0]
+
+
+def test_genres_include_counts(monkeypatch):
+    html = load_fixture("genres.html")
+    dirs = []
+
+    monkeypatch.setattr(animeidhentai.utils, "getHtml", lambda *a, **k: html)
+    monkeypatch.setattr(animeidhentai.utils, "eod", lambda: None)
+    monkeypatch.setattr(animeidhentai.site, "add_dir", lambda *a, **k: dirs.append(a))
+
+    animeidhentai.animeidhentai_genres("https://animeidhentai.com/genres/")
+
+    labels = [entry[0] for entry in dirs]
+    assert labels == [
+        "Action [COLOR cyan]12 Videos[/COLOR]",
+        "Romance [COLOR cyan]8 Videos[/COLOR]",
+    ]
+
+
+def test_years_uses_selector(monkeypatch):
+    html = load_fixture("years.html")
+    selected = {}
+    called_urls = []
+
+    monkeypatch.setattr(animeidhentai.utils, "getHtml", lambda *a, **k: html)
+
+    def fake_selector(prompt, options, reverse=False):
+        selected["prompt"] = prompt
+        selected["options"] = options
+        selected["reverse"] = reverse
+        return "2022"
+
+    monkeypatch.setattr(animeidhentai.utils, "selector", fake_selector)
+    monkeypatch.setattr(animeidhentai, "animeidhentai_list", lambda url: called_urls.append(url))
+
+    animeidhentai.Years("https://animeidhentai.com/?s=")
+
+    assert selected["reverse"] is True
+    assert "2022" in selected["options"]
+    assert called_urls == ["https://animeidhentai.com/year/2022/"]
+
+
+def test_play_prefers_nhplayer_sources(monkeypatch):
+    html_map = {
+        "https://animeidhentai.com/watch/video": load_fixture("play_main.html"),
+        "https://nhplayer.com/embed/abc123": load_fixture("play_nhplayer.html"),
+        "https://nhplayer.com/videos/abc123.m3u8": load_fixture("play_source.html"),
+    }
+
+    captured = {}
+
+    def fake_get_html(url, *args, **kwargs):
+        return html_map[url]
+
+    class DummyVP:
+        def __init__(self, name, download=None):
+            self.progress = type("P", (), {
+                "update": lambda *a, **k: None,
+                "close": lambda *a, **k: captured.setdefault("closed", True),
+            })()
+            self.direct_regex = None
+
+        def __setattr__(self, name, value):
+            if name == "direct_regex":
+                captured["direct_regex"] = value
+            super().__setattr__(name, value)
+
+        def play_from_html(self, html):
+            captured["html_played"] = html
+
+        def play_from_link_to_resolve(self, url):
+            captured["resolved_url"] = url
+
+    monkeypatch.setattr(animeidhentai.utils, "VideoPlayer", DummyVP)
+    monkeypatch.setattr(animeidhentai.utils, "getHtml", fake_get_html)
+    monkeypatch.setattr(animeidhentai.utils, "notify", lambda *a, **k: captured.setdefault("notified", True))
+
+    animeidhentai.animeidhentai_play("https://animeidhentai.com/watch/video", "Sample")
+
+    assert "video.m3u8" in captured.get("html_played", "")
+    assert captured.get("direct_regex") == r'file:\s*"([^"]+)"'
+    assert "resolved_url" not in captured
+    assert captured.get("closed") is True


### PR DESCRIPTION
## Summary
- migrate animeidhentai scraper to BeautifulSoup selectors for listings, genres, years, and playback
- add fixtures and tests covering animeidhentai listings, filters, and nhplayer playback flow

## Testing
- python -m pytest tests/sites/test_animeidhentai.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69337bbf027c8327bd9b90a1ebbb383b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Display video quality indicators (FHD/HD) for anime entries
  * Improved pagination with clear "Next Page" navigation
  * Genre listings now show video counts

* **Bug Fixes**
  * Enhanced error handling and user notifications for missing content
  * Improved video playback URL detection with better fallback support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->