### PR TITLE
Add parsing helper tests and normalize utils output

### DIFF
--- a/plugin.video.cumination/resources/lib/utils.py
+++ b/plugin.video.cumination/resources/lib/utils.py
@@ -1426,34 +1426,41 @@ def cleantext(text):
     else:
         h = html_parser.HTMLParser()
         text = h.unescape(text.decode('utf8')).encode('utf8')
-    text = text.replace('&amp;', '&')
-    text = text.replace('&apos;', "'")
-    text = text.replace('&lt;', '<')
-    text = text.replace('&gt;', '>')
-    text = text.replace('&ndash;', '-')
-    text = text.replace('&quot;', '"')
-    text = text.replace('&ntilde;', '~')
-    text = text.replace('&rsquo;', '\'')
-    text = text.replace('&nbsp;', ' ')
-    text = text.replace('\xa0', ' ')
-    text = text.replace('&equals;', '=')
-    text = text.replace('&quest;', '?')
-    text = text.replace('&comma;', ',')
-    text = text.replace('&period;', '.')
-    text = text.replace('&colon;', ':')
-    text = text.replace('&lpar;', '(')
-    text = text.replace('&rpar;', ')')
-    text = text.replace('&excl;', '!')
-    text = text.replace('&dollar;', '$')
-    text = text.replace('&num;', '#')
-    text = text.replace('&ast;', '*')
-    text = text.replace('&lowbar;', '_')
-    text = text.replace('&lsqb;', '[')
-    text = text.replace('&rsqb;', ']')
-    text = text.replace('&half;', '1/2')
-    text = text.replace('&DiacriticalTilde;', '~')
-    text = text.replace('&OpenCurlyDoubleQuote;', '"')
-    text = text.replace('&CloseCurlyDoubleQuote;', '"')
+
+    replacements = {
+        '&amp;': '&',
+        '&apos;': "'",
+        '&colon;': ':',
+        '&comma;': ',',
+        '&dollar;': '$',
+        '&equals;': '=',
+        '&excl;': '!',
+        '&gt;': '>',
+        '&half;': '1/2',
+        '&lpar;': '(',
+        '&lowbar;': '_',
+        '&lsqb;': '[',
+        '&lt;': '<',
+        '&nbsp;': ' ',
+        '\xa0': ' ',
+        '&ntilde;': '~',
+        '&num;': '#',
+        '&OpenCurlyDoubleQuote;': '"',
+        '&period;': '.',
+        '&quest;': '?',
+        '&quot;': '"',
+        '&rpar;': ')',
+        '&rsqb;': ']',
+        '&rsquo;': "'",
+        '&ndash;': '-',
+        '&ast;': '*',
+        '&DiacriticalTilde;': '~',
+        '&CloseCurlyDoubleQuote;': '"',
+    }
+
+    for key, value in replacements.items():
+        text = text.replace(key, value)
+
     return text.strip()
 
 
@@ -1468,13 +1475,27 @@ def get_vidhost(url):
     Trim the url to get the video hoster
     :return vidhost
     """
-    parts = url.split('/')[2].split('.')
+    normalized_url = url
+    if not re.match(r'^[a-zA-Z][a-zA-Z0-9+\.-]*://', url):
+        normalized_url = f'//{url.lstrip('/')}'
+
+    parsed_url = urllib_parse.urlparse(normalized_url)
+    hostname = parsed_url.hostname
+    if not hostname:
+        return ""
+
+    parts = hostname.split('.')
+
+    # Handle IPv4 addresses directly
+    if len(parts) == 4 and all(part.isdigit() for part in parts):
+        return hostname
+
     if len(parts) >= 3 and len(parts[-1]) == 2 and len(parts[-2]) <= 3:
         # Handle common country code TLDs such as co.uk, com.au, etc.
-        vidhost = '.'.join(parts[-3:])
-    else:
-        vidhost = '{}.{}'.format(parts[-2], parts[-1])
-    return vidhost
+        return '.'.join(parts[-3:])
+    if len(parts) >= 2:
+        return '{}.{}'.format(parts[-2], parts[-1])
+    return hostname
 
 
 def get_language(lang_code):

--- a/tests/test_utils_parsing_helpers.py
+++ b/tests/test_utils_parsing_helpers.py
@@ -30,12 +30,16 @@ def test_parse_query_gracefully_handles_invalid_ints():
     assert result["mode"] == "custom"
 
 
-def test_cleantext_unescapes_entities_and_strips():
-    messy = "  &lt;Hello&nbsp;World&gt; &amp; other&amp;apos;s&nbsp; "
-
-    cleaned = utils.cleantext(messy)
-
-    assert cleaned == "<Hello World> & other's"
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("  &lt;Hello&nbsp;World&gt; &amp; other&amp;apos;s&nbsp; ", "<Hello World> & other's"),
+        ("&nbsp;\xa0", ""),
+        ("no_entities", "no_entities"),
+    ],
+)
+def test_cleantext_unescapes_entities_and_strips(raw, expected):
+    assert utils.cleantext(raw) == expected
 
 
 def test_cleanhtml_strips_tags_preserving_text():
@@ -54,8 +58,19 @@ def test_fix_url_handles_protocol_and_baseurl():
     assert utils.fix_url("//cdn.example.com/img.png", siteurl=siteurl) == "https://cdn.example.com/img.png"
 
 
-def test_get_vidhost_extracts_base_domain():
-    assert utils.get_vidhost("https://media.sub.hosting.example.co.uk/video.mp4") == "example.co.uk"
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://media.sub.hosting.example.co.uk/video.mp4", "example.co.uk"),
+        ("http://example.com/path", "example.com"),
+        ("https://google.com.au/watch", "google.com.au"),
+        ("http://localhost:8080", "localhost"),
+        ("192.168.1.10/video", "192.168.1.10"),
+        ("//cdn.example.com/resource", "example.com"),
+    ],
+)
+def test_get_vidhost_extracts_base_domain(url, expected):
+    assert utils.get_vidhost(url) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add targeted unit tests for query parsing, text cleaning, URL normalization, and language helpers
- normalize cleantext handling of non-breaking spaces and improve video host extraction for ccTLDs

## Testing
- pytest tests/test_utils_parsing_helpers.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69372248ad8c8327a6730857f5d6cc66)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text processing: better unescaping of HTML entities, normalization of non-breaking spaces, and more robust trimming of extraneous whitespace.
  * Enhanced URL host extraction: correctly handles IPs and multi-segment country-code domains for more accurate base-domain detection.

* **Tests**
  * Added comprehensive tests for parsing, URL handling, text/html cleaning, and locale resolution utilities to validate edge cases and common paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->