### PR TITLE
Migrate vaginanl and perverzija to BeautifulSoup

### DIFF
--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -173,7 +173,7 @@ this table is the authoritative tracker for completion status.
 | rule34video | ✅ **COMPLETED** | BeautifulSoup for List, TagMenu, Tag, Cats with comprehensive tests (2025-12-07) |
 | taboofantazy | ✅ **COMPLETED** | BeautifulSoup for List, Cat, Tags with comprehensive tests (2025-12-06) |
 
-#### ⏳ Sub-Phase 6: International Sites (4/15 completed)
+#### ⏳ Sub-Phase 6: International Sites (6/15 completed)
 
 | Site | Status | Region |
 |------|--------|--------|
@@ -181,8 +181,8 @@ this table is the authoritative tracker for completion status.
 | porno1hu | ✅ **COMPLETED** | Hungarian |
 | porno365 | ✅ **COMPLETED** | Russian |
 | nltubes | ✅ **COMPLETED** | Dutch |
-| vaginanl | ⏳ Pending | Dutch |
-| perverzija | ⏳ Pending | Balkan |
+| vaginanl | ✅ **COMPLETED** | Dutch |
+| perverzija | ✅ **COMPLETED** | Balkan |
 | viralvideosporno | ⏳ Pending | Spanish |
 | netfapx | ⏳ Pending | International |
 | porntn | ⏳ Pending | International |

--- a/plugin.video.cumination/resources/lib/sites/UNMIGRATED_CHECKLIST.md
+++ b/plugin.video.cumination/resources/lib/sites/UNMIGRATED_CHECKLIST.md
@@ -19,8 +19,8 @@ This checklist groups regex-heavy site modules under `resources/lib/sites/` by m
 - [x] `porno1hu.py`
 - [x] `porno365.py`
 - [x] `nltubes.py`
-- [ ] `vaginanl.py`
-- [ ] `perverzija.py`
+- [x] `vaginanl.py`
+- [x] `perverzija.py`
 - [ ] `viralvideosporno.py`
 - [ ] `netfapx.py`
 - [ ] `porntn.py`

--- a/tests/fixtures/perverzija/list.html
+++ b/tests/fixtures/perverzija/list.html
@@ -1,0 +1,26 @@
+<html>
+  <body>
+    <div class="video-listing-filter">
+      <div class="item-thumbnail">
+        <a href="/videos/first-video" title="First Video">
+          <img src="https://tube.perverzija.com/thumbs/first.jpg" alt="First Video" />
+          <span class="time_dur">10:21</span>
+        </a>
+      </div>
+      <div class="item-thumbnail">
+        <a href="https://tube.perverzija.com/videos/second-video" title="Second Video">
+          <img data-src="//tube.perverzija.com/thumbs/second.jpg" alt="Second Video" />
+        </a>
+      </div>
+      <div class="item-thumbnail">
+        <a href="/videos/invalid" title="">
+          <img src="https://tube.perverzija.com/thumbs/invalid.jpg" />
+        </a>
+      </div>
+    </div>
+    <div class="pagination">
+      <span class="pages">Page 1 of 3</span>
+      <a rel="next" aria-label="Next Page" href="https://tube.perverzija.com/page/2/">Next</a>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/perverzija/tags.html
+++ b/tests/fixtures/perverzija/tags.html
@@ -1,0 +1,16 @@
+<html>
+  <body>
+    <div class="tag-cloud">
+      <a href="tag/bondage/">Bondage (12)</a>
+      <a href="tag/cosplay/">Cosplay (8)</a>
+    </div>
+    <div class="studio-cloud">
+      <a href="studio/studio-one/">Studio One (5)</a>
+      <a href="studio/studio-two/">Studio Two (9)</a>
+    </div>
+    <div class="stars-cloud">
+      <a href="stars/star-one/">Star One (3)</a>
+      <a href="stars/star-two/">Star Two (7)</a>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/vaginanl/categories.html
+++ b/tests/fixtures/vaginanl/categories.html
@@ -1,0 +1,21 @@
+<html>
+  <body>
+    <div class="card">
+      <a href="/categories/teen">
+        <img data-src="https://cdn.vagina.nl/cat/teen.jpg" alt="Teen" />
+        <span class="title">Teen</span>
+      </a>
+    </div>
+    <div class="card">
+      <a href="https://vagina.nl/categories/hardcore">
+        <img src="https://cdn.vagina.nl/cat/hardcore.jpg" alt="Hardcore" />
+        <span class="card-title">Hardcore</span>
+      </a>
+    </div>
+    <div class="card">
+      <a href="/categories/skip">
+        <img src="https://cdn.vagina.nl/cat/skip.jpg" />
+      </a>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/vaginanl/list.html
+++ b/tests/fixtures/vaginanl/list.html
@@ -1,0 +1,26 @@
+<html>
+  <body>
+    <div class="card">
+      <a class="thumbnail-link" href="/sexfilms/first-video" title="First Video">
+        <img data-src="https://cdn.vagina.nl/thumbs/first.jpg" alt="First Video" />
+        <span class="duration">12:34</span>
+      </a>
+    </div>
+    <div class="card">
+      <a class="thumbnail-link" href="https://vagina.nl/sexfilms/second-video" title="Second Video">
+        <img src="//cdn.vagina.nl/thumbs/second.jpg" alt="Second Video" />
+        <span class="video-duration">08:01</span>
+      </a>
+    </div>
+    <div class="card">
+      <a class="thumbnail-link" href="/sexfilms/skip-video">
+        <img data-src="https://cdn.vagina.nl/thumbs/skip.jpg" />
+      </a>
+    </div>
+    <ul class="pagination">
+      <li><a href="/sexfilms/newest?page=1">1</a></li>
+      <li><a href="/sexfilms/newest?page=5">5</a></li>
+      <li class="next"><a rel="next" href="/sexfilms/newest?page=2">Next</a></li>
+    </ul>
+  </body>
+</html>

--- a/tests/sites/test_perverzija.py
+++ b/tests/sites/test_perverzija.py
@@ -1,0 +1,134 @@
+"""Tests for perverzija BeautifulSoup migration."""
+from pathlib import Path
+
+from resources.lib.sites import perverzija
+
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "perverzija"
+
+
+def load_fixture(name: str) -> str:
+    return (FIXTURE_DIR / name).read_text(encoding="utf-8")
+
+
+def test_list_parses_items(monkeypatch):
+    html = load_fixture("list.html")
+
+    downloads = []
+    dirs = []
+
+    monkeypatch.setattr(perverzija.utils, "getHtml", lambda *a, **k: html)
+    monkeypatch.setattr(perverzija.utils, "eod", lambda: None)
+
+    def fake_add_download_link(name, url, mode, iconimage, desc, contextm=None, duration="", **kwargs):
+        downloads.append(
+            {
+                "name": name,
+                "url": url,
+                "mode": mode,
+                "icon": iconimage,
+                "desc": desc,
+                "contextm": contextm,
+                "duration": duration,
+            }
+        )
+
+    def fake_add_dir(name, url, mode, iconimage=None, **kwargs):
+        dirs.append({"name": name, "url": url, "mode": mode, "icon": iconimage})
+
+    monkeypatch.setattr(perverzija.site, "add_download_link", fake_add_download_link)
+    monkeypatch.setattr(perverzija.site, "add_dir", fake_add_dir)
+
+    perverzija.List("https://tube.perverzija.com/page/1/")
+
+    assert len(downloads) == 2
+
+    first = downloads[0]
+    assert first["name"] == "First Video"
+    assert first["url"] == "https://tube.perverzija.com/videos/first-video"
+    assert first["icon"] == "https://tube.perverzija.com/thumbs/first.jpg"
+    assert first["duration"] == "10:21"
+    assert first["contextm"][0][0].startswith("[COLOR deeppink]Lookup info")
+
+    second = downloads[1]
+    assert second["name"] == "Second Video"
+    assert second["url"] == "https://tube.perverzija.com/videos/second-video"
+    assert second["contextm"] is not None
+
+    assert any(d["mode"] == "List" for d in dirs)
+
+
+def test_list_pagination(monkeypatch):
+    html = load_fixture("list.html")
+    dirs = []
+
+    monkeypatch.setattr(perverzija.utils, "getHtml", lambda *a, **k: html)
+    monkeypatch.setattr(perverzija.utils, "eod", lambda: None)
+    monkeypatch.setattr(perverzija.site, "add_download_link", lambda *a, **k: None)
+
+    def fake_add_dir(name, url, mode, iconimage=None, **kwargs):
+        dirs.append({"name": name, "url": url, "mode": mode})
+
+    monkeypatch.setattr(perverzija.site, "add_dir", fake_add_dir)
+
+    perverzija.List("https://tube.perverzija.com/page/1/")
+
+    assert dirs[0]["name"] == "Next Page... (Currently in Page 1 of 3)"
+    assert dirs[0]["url"] == "https://tube.perverzija.com/page/2/"
+
+
+def test_tag_parsing(monkeypatch):
+    html = load_fixture("tags.html")
+    dirs = []
+
+    monkeypatch.setattr(perverzija.utils, "getHtml", lambda *a, **k: html)
+    monkeypatch.setattr(perverzija.utils, "eod", lambda: None)
+
+    def fake_add_dir(name, url, mode, iconimage=None, **kwargs):
+        dirs.append({"name": name, "url": url, "mode": mode})
+
+    monkeypatch.setattr(perverzija.site, "add_dir", fake_add_dir)
+
+    perverzija.Tag("https://tube.perverzija.com/tags/")
+
+    assert len(dirs) == 2
+    assert dirs[0]["name"] == "Bondage (12)"
+    assert dirs[0]["url"] == "https://tube.perverzija.com/tag/bondage/"
+
+
+def test_studios_parsing(monkeypatch):
+    html = load_fixture("tags.html")
+    dirs = []
+
+    monkeypatch.setattr(perverzija.utils, "getHtml", lambda *a, **k: html)
+    monkeypatch.setattr(perverzija.utils, "eod", lambda: None)
+
+    def fake_add_dir(name, url, mode, iconimage=None, **kwargs):
+        dirs.append({"name": name, "url": url, "mode": mode})
+
+    monkeypatch.setattr(perverzija.site, "add_dir", fake_add_dir)
+
+    perverzija.Studios("https://tube.perverzija.com/studios/")
+
+    assert len(dirs) == 2
+    assert dirs[1]["name"] == "Studio Two (9)"
+    assert dirs[1]["url"] == "https://tube.perverzija.com/studio/studio-two/"
+
+
+def test_stars_parsing(monkeypatch):
+    html = load_fixture("tags.html")
+    dirs = []
+
+    monkeypatch.setattr(perverzija.utils, "getHtml", lambda *a, **k: html)
+    monkeypatch.setattr(perverzija.utils, "eod", lambda: None)
+
+    def fake_add_dir(name, url, mode, iconimage=None, **kwargs):
+        dirs.append({"name": name, "url": url, "mode": mode})
+
+    monkeypatch.setattr(perverzija.site, "add_dir", fake_add_dir)
+
+    perverzija.Stars("https://tube.perverzija.com/stars/")
+
+    assert len(dirs) == 2
+    assert dirs[0]["name"] == "Star One (3)"
+    assert dirs[0]["url"] == "https://tube.perverzija.com/stars/star-one/"

--- a/tests/sites/test_vaginanl.py
+++ b/tests/sites/test_vaginanl.py
@@ -1,0 +1,104 @@
+"""Tests for vaginanl site BeautifulSoup parsing."""
+from pathlib import Path
+
+from resources.lib.sites import vaginanl
+
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "vaginanl"
+
+
+def load_fixture(name: str) -> str:
+    return (FIXTURE_DIR / name).read_text(encoding="utf-8")
+
+
+def test_list_parses_cards(monkeypatch):
+    html = load_fixture("list.html")
+
+    downloads = []
+    dirs = []
+
+    monkeypatch.setattr(vaginanl.utils, "getHtml", lambda *a, **k: html)
+    monkeypatch.setattr(vaginanl.utils, "eod", lambda: None)
+
+    def fake_add_download_link(name, url, mode, iconimage, desc, duration="", **kwargs):
+        downloads.append(
+            {
+                "name": name,
+                "url": url,
+                "mode": mode,
+                "icon": iconimage,
+                "desc": desc,
+                "duration": duration,
+            }
+        )
+
+    def fake_add_dir(name, url, mode, iconimage=None, **kwargs):
+        dirs.append({"name": name, "url": url, "mode": mode, "icon": iconimage})
+
+    monkeypatch.setattr(vaginanl.site, "add_download_link", fake_add_download_link)
+    monkeypatch.setattr(vaginanl.site, "add_dir", fake_add_dir)
+
+    vaginanl.List("https://vagina.nl/sexfilms/newest")
+
+    assert len(downloads) == 2
+
+    first = downloads[0]
+    assert first["name"] == "First Video"
+    assert first["url"] == "https://vagina.nl/sexfilms/first-video"
+    assert first["mode"] == "Playvid"
+    assert first["icon"].startswith("https://cdn.vagina.nl/thumbs/first.jpg")
+    assert first["duration"] == "12:34"
+
+    second = downloads[1]
+    assert second["name"] == "Second Video"
+    assert second["url"] == "https://vagina.nl/sexfilms/second-video"
+    assert second["duration"] == "08:01"
+
+    assert len([d for d in dirs if d["mode"] == "List"]) == 1
+
+
+def test_list_adds_pagination(monkeypatch):
+    html = load_fixture("list.html")
+    dirs = []
+
+    monkeypatch.setattr(vaginanl.utils, "getHtml", lambda *a, **k: html)
+    monkeypatch.setattr(vaginanl.utils, "eod", lambda: None)
+    monkeypatch.setattr(vaginanl.site, "add_download_link", lambda *a, **k: None)
+
+    def fake_add_dir(name, url, mode, iconimage=None, **kwargs):
+        dirs.append({"name": name, "url": url, "mode": mode, "icon": iconimage})
+
+    monkeypatch.setattr(vaginanl.site, "add_dir", fake_add_dir)
+
+    vaginanl.List("https://vagina.nl/sexfilms/newest")
+
+    assert dirs[0]["name"] == "Next Page (2/5)"
+    assert dirs[0]["url"] == "https://vagina.nl/sexfilms/newest?page=2"
+    assert dirs[0]["mode"] == "List"
+
+
+def test_categories_parses_cards(monkeypatch):
+    html = load_fixture("categories.html")
+    dirs = []
+
+    monkeypatch.setattr(vaginanl.utils, "getHtml", lambda *a, **k: html)
+    monkeypatch.setattr(vaginanl.utils, "eod", lambda: None)
+
+    def fake_add_dir(name, url, mode, iconimage=None, **kwargs):
+        dirs.append({"name": name, "url": url, "mode": mode, "icon": iconimage})
+
+    monkeypatch.setattr(vaginanl.site, "add_dir", fake_add_dir)
+
+    vaginanl.Categories("https://vagina.nl/categories")
+
+    assert len(dirs) == 2
+
+    first = dirs[0]
+    assert first["name"] == "Teen"
+    assert first["url"] == "https://vagina.nl/categories/teen"
+    assert first["icon"] == "https://cdn.vagina.nl/cat/teen.jpg"
+
+    second = dirs[1]
+    assert second["name"] == "Hardcore"
+    assert second["url"] == "https://vagina.nl/categories/hardcore"
+    assert second["icon"] == "https://cdn.vagina.nl/cat/hardcore.jpg"


### PR DESCRIPTION
## Summary
- migrate vaginanl and perverzija site modules to BeautifulSoup-based parsing for listings, categories, and metadata
- add new fixtures and unit tests covering listings, pagination, and taxonomy navigation for both sites
- update migration documentation to mark the international sites as completed

## Testing
- pytest tests/sites/test_vaginanl.py tests/sites/test_perverzija.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694326ed85c08327845c99bdf87744f6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced video parsing stability on two international video sites, making the plugin more resilient to website layout changes.
  * Improved handling of missing or malformed video metadata fields during parsing.
  * Strengthened pagination and category navigation reliability.

* **Chores**
  * Updated internal migration tracking documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->