### PR TITLE
Potential fix for code scanning alert no. 104: Default version of SSL/TLS may be insecure

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/lib/websocket/_http.py
+++ b/script.module.resolveurl/lib/resolveurl/lib/websocket/_http.py
@@ -264,6 +264,7 @@ def _ssl_socket(sock, user_sslopt, hostname):
         sock = _wrap_sni_socket(sock, sslopt, hostname, check_hostname)
     else:
         sslopt.pop('check_hostname', True)
+        sslopt.setdefault('ssl_version', ssl.PROTOCOL_TLSv1_2)
         sock = ssl.wrap_socket(sock, **sslopt)
 
     if not HAVE_CONTEXT_CHECK_HOSTNAME and check_hostname:

--- a/script.module.resolveurl/lib/resolveurl/lib/websocket/_http.py
+++ b/script.module.resolveurl/lib/resolveurl/lib/websocket/_http.py
@@ -18,6 +18,7 @@ Copyright (C) 2010 Hiroki Ohtani(liris)
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
+
 import errno
 import os
 import socket
@@ -27,7 +28,7 @@ import six
 
 from ._exceptions import *
 from ._logging import *
-from ._socket import*
+from ._socket import *
 from ._ssl_compat import *
 from ._url import *
 
@@ -40,20 +41,24 @@ __all__ = ["proxy_info", "connect", "read_headers"]
 
 try:
     import socks
+
     ProxyConnectionError = socks.ProxyConnectionError
     HAS_PYSOCKS = True
 except:
+
     class ProxyConnectionError(BaseException):
         pass
+
     HAS_PYSOCKS = False
 
 
 class proxy_info(object):
-
     def __init__(self, **options):
         self.type = options.get("proxy_type") or "http"
-        if not(self.type in ['http', 'socks4', 'socks5', 'socks5h']):
-            raise ValueError("proxy_type must be 'http', 'socks4', 'socks5' or 'socks5h'")
+        if not (self.type in ["http", "socks4", "socks5", "socks5h"]):
+            raise ValueError(
+                "proxy_type must be 'http', 'socks4', 'socks5' or 'socks5h'"
+            )
         self.host = options.get("http_proxy_host", None)
         if self.host:
             self.port = options.get("http_proxy_port", 0)
@@ -89,7 +94,7 @@ def _open_proxied_socket(url, options, proxy):
         proxy_username=proxy.auth[0] if proxy.auth else None,
         proxy_password=proxy.auth[1] if proxy.auth else None,
         timeout=options.timeout,
-        socket_options=DEFAULT_SOCKET_OPTION + options.sockopt
+        socket_options=DEFAULT_SOCKET_OPTION + options.sockopt,
     )
 
     if is_secure:
@@ -102,7 +107,7 @@ def _open_proxied_socket(url, options, proxy):
 
 
 def connect(url, options, proxy, socket):
-    if proxy.host and not socket and not (proxy.type == 'http'):
+    if proxy.host and not socket and not (proxy.type == "http"):
         return _open_proxied_socket(url, options, proxy)
 
     hostname, port, resource, is_secure = parse_url(url)
@@ -111,10 +116,10 @@ def connect(url, options, proxy, socket):
         return socket, (hostname, port, resource)
 
     addrinfo_list, need_tunnel, auth = _get_addrinfo_list(
-        hostname, port, is_secure, proxy)
+        hostname, port, is_secure, proxy
+    )
     if not addrinfo_list:
-        raise WebSocketException(
-            "Host not found.: " + hostname + ":" + str(port))
+        raise WebSocketException("Host not found.: " + hostname + ":" + str(port))
 
     sock = None
     try:
@@ -137,14 +142,16 @@ def connect(url, options, proxy, socket):
 
 def _get_addrinfo_list(hostname, port, is_secure, proxy):
     phost, pport, pauth = get_proxy_info(
-        hostname, is_secure, proxy.host, proxy.port, proxy.auth, proxy.no_proxy)
+        hostname, is_secure, proxy.host, proxy.port, proxy.auth, proxy.no_proxy
+    )
     try:
         # when running on windows 10, getaddrinfo without socktype returns a socktype 0.
         # This generates an error exception: `_on_error: exception Socket type must be stream or datagram, not 0`
         # or `OSError: [Errno 22] Invalid argument` when creating socket. Force the socket type to SOCK_STREAM.
         if not phost:
             addrinfo_list = socket.getaddrinfo(
-                hostname, port, 0, socket.SOCK_STREAM, socket.SOL_TCP)
+                hostname, port, 0, socket.SOCK_STREAM, socket.SOL_TCP
+            )
             return addrinfo_list, False, None
         else:
             pport = pport and pport or 80
@@ -152,7 +159,9 @@ def _get_addrinfo_list(hostname, port, is_secure, proxy):
             # returns a socktype 0. This generates an error exception:
             # _on_error: exception Socket type must be stream or datagram, not 0
             # Force the socket type to SOCK_STREAM
-            addrinfo_list = socket.getaddrinfo(phost, pport, 0, socket.SOCK_STREAM, socket.SOL_TCP)
+            addrinfo_list = socket.getaddrinfo(
+                phost, pport, 0, socket.SOCK_STREAM, socket.SOL_TCP
+            )
             return addrinfo_list, True, pauth
     except socket.gaierror as e:
         raise WebSocketAddressException(e)
@@ -183,7 +192,7 @@ def _open_socket(addrinfo_list, sockopt, timeout):
                 try:
                     eConnRefused = (errno.ECONNREFUSED, errno.WSAECONNREFUSED)
                 except:
-                    eConnRefused = (errno.ECONNREFUSED, )
+                    eConnRefused = (errno.ECONNREFUSED,)
                 if error.errno == errno.EINTR:
                     continue
                 elif error.errno in eConnRefused:
@@ -208,38 +217,38 @@ def _can_use_sni():
 
 
 def _wrap_sni_socket(sock, sslopt, hostname, check_hostname):
-    context = ssl.SSLContext(sslopt.get('ssl_version', ssl.PROTOCOL_SSLv23))
+    context = ssl.SSLContext(sslopt.get("ssl_version", ssl.PROTOCOL_SSLv23))
 
-    if sslopt.get('cert_reqs', ssl.CERT_NONE) != ssl.CERT_NONE:
-        cafile = sslopt.get('ca_certs', None)
-        capath = sslopt.get('ca_cert_path', None)
+    if sslopt.get("cert_reqs", ssl.CERT_NONE) != ssl.CERT_NONE:
+        cafile = sslopt.get("ca_certs", None)
+        capath = sslopt.get("ca_cert_path", None)
         if cafile or capath:
             context.load_verify_locations(cafile=cafile, capath=capath)
-        elif hasattr(context, 'load_default_certs'):
+        elif hasattr(context, "load_default_certs"):
             context.load_default_certs(ssl.Purpose.SERVER_AUTH)
-    if sslopt.get('certfile', None):
+    if sslopt.get("certfile", None):
         context.load_cert_chain(
-            sslopt['certfile'],
-            sslopt.get('keyfile', None),
-            sslopt.get('password', None),
+            sslopt["certfile"],
+            sslopt.get("keyfile", None),
+            sslopt.get("password", None),
         )
     # see
     # https://github.com/liris/websocket-client/commit/b96a2e8fa765753e82eea531adb19716b52ca3ca#commitcomment-10803153
-    context.verify_mode = sslopt['cert_reqs']
+    context.verify_mode = sslopt["cert_reqs"]
     if HAVE_CONTEXT_CHECK_HOSTNAME:
         context.check_hostname = check_hostname
-    if 'ciphers' in sslopt:
-        context.set_ciphers(sslopt['ciphers'])
-    if 'cert_chain' in sslopt:
-        certfile, keyfile, password = sslopt['cert_chain']
+    if "ciphers" in sslopt:
+        context.set_ciphers(sslopt["ciphers"])
+    if "cert_chain" in sslopt:
+        certfile, keyfile, password = sslopt["cert_chain"]
         context.load_cert_chain(certfile, keyfile, password)
-    if 'ecdh_curve' in sslopt:
-        context.set_ecdh_curve(sslopt['ecdh_curve'])
+    if "ecdh_curve" in sslopt:
+        context.set_ecdh_curve(sslopt["ecdh_curve"])
 
     return context.wrap_socket(
         sock,
-        do_handshake_on_connect=sslopt.get('do_handshake_on_connect', True),
-        suppress_ragged_eofs=sslopt.get('suppress_ragged_eofs', True),
+        do_handshake_on_connect=sslopt.get("do_handshake_on_connect", True),
+        suppress_ragged_eofs=sslopt.get("suppress_ragged_eofs", True),
         server_hostname=hostname,
     )
 
@@ -248,23 +257,30 @@ def _ssl_socket(sock, user_sslopt, hostname):
     sslopt = dict(cert_reqs=ssl.CERT_REQUIRED)
     sslopt.update(user_sslopt)
 
-    certPath = os.environ.get('WEBSOCKET_CLIENT_CA_BUNDLE')
-    if certPath and os.path.isfile(certPath) \
-            and user_sslopt.get('ca_certs', None) is None \
-            and user_sslopt.get('ca_cert', None) is None:
-        sslopt['ca_certs'] = certPath
-    elif certPath and os.path.isdir(certPath) \
-            and user_sslopt.get('ca_cert_path', None) is None:
-        sslopt['ca_cert_path'] = certPath
+    certPath = os.environ.get("WEBSOCKET_CLIENT_CA_BUNDLE")
+    if (
+        certPath
+        and os.path.isfile(certPath)
+        and user_sslopt.get("ca_certs", None) is None
+        and user_sslopt.get("ca_cert", None) is None
+    ):
+        sslopt["ca_certs"] = certPath
+    elif (
+        certPath
+        and os.path.isdir(certPath)
+        and user_sslopt.get("ca_cert_path", None) is None
+    ):
+        sslopt["ca_cert_path"] = certPath
 
     check_hostname = sslopt["cert_reqs"] != ssl.CERT_NONE and sslopt.pop(
-        'check_hostname', True)
+        "check_hostname", True
+    )
 
     if _can_use_sni():
         sock = _wrap_sni_socket(sock, sslopt, hostname, check_hostname)
     else:
-        sslopt.pop('check_hostname', True)
-        sslopt.setdefault('ssl_version', ssl.PROTOCOL_TLSv1_2)
+        sslopt.pop("check_hostname", True)
+        sslopt.setdefault("ssl_version", ssl.PROTOCOL_TLSv1_2)
         sock = ssl.wrap_socket(sock, **sslopt)
 
     if not HAVE_CONTEXT_CHECK_HOSTNAME and check_hostname:
@@ -283,7 +299,7 @@ def _tunnel(sock, host, port, auth):
         auth_str = auth[0]
         if auth[1]:
             auth_str += ":" + auth[1]
-        encoded_str = base64encode(auth_str.encode()).strip().decode().replace('\n', '')
+        encoded_str = base64encode(auth_str.encode()).strip().decode().replace("\n", "")
         connect_header += "Proxy-Authorization: Basic %s\r\n" % encoded_str
     connect_header += "\r\n"
     dump("request header", connect_header)
@@ -296,8 +312,7 @@ def _tunnel(sock, host, port, auth):
         raise WebSocketProxyException(str(e))
 
     if status != 200:
-        raise WebSocketProxyException(
-            "failed CONNECT via proxy status: %r" % status)
+        raise WebSocketProxyException("failed CONNECT via proxy status: %r" % status)
 
     return sock
 
@@ -310,12 +325,11 @@ def read_headers(sock):
 
     while True:
         line = recv_line(sock)
-        line = line.decode('utf-8').strip()
+        line = line.decode("utf-8").strip()
         if not line:
             break
         trace(line)
         if not status:
-
             status_info = line.split(" ", 2)
             status = int(status_info[1])
             if len(status_info) > 2:
@@ -325,7 +339,9 @@ def read_headers(sock):
             if len(kv) == 2:
                 key, value = kv
                 if key.lower() == "set-cookie" and headers.get("set-cookie"):
-                    headers["set-cookie"] = headers.get("set-cookie") + "; " + value.strip()
+                    headers["set-cookie"] = (
+                        headers.get("set-cookie") + "; " + value.strip()
+                    )
                 else:
                     headers[key.lower()] = value.strip()
             else:


### PR DESCRIPTION
Potential fix for [https://github.com/rpeters1430/repository.dobbelina/security/code-scanning/104](https://github.com/rpeters1430/repository.dobbelina/security/code-scanning/104)

To fix this without changing intended functionality, ensure the non-SNI `ssl.wrap_socket` call always receives an explicit, modern TLS protocol when none is provided.

Best targeted fix in this file:
- In `_ssl_socket` (around lines 263–268), before calling `ssl.wrap_socket`, set a default `ssl_version` in `sslopt` if it is absent.
- Use `ssl.PROTOCOL_TLSv1_2` as the secure minimum aligned with your stated recommendation.
- Keep existing user-provided `ssl_version` untouched (so behavior remains configurable).

This change is minimal, local, and addresses the exact CodeQL finding.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
