### PR TITLE
Potential fix for code scanning alert no. 174: Full server-side request forgery

### DIFF
--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -696,9 +696,26 @@ def Playvid(url, name):
                             if not req_url:
                                 self.send_error(400)
                                 return
+                            def _is_allowed_remote_url(u):
+                                try:
+                                    p = urllib_parse.urlparse(u)
+                                except Exception:
+                                    return False
+                                if p.scheme not in ('http', 'https'):
+                                    return False
+                                if not p.netloc:
+                                    return False
+                                host = (p.hostname or '').lower()
+                                return host == 'chaturbate.com' or host.endswith('.chaturbate.com')
+                            if not _is_allowed_remote_url(req_url):
+                                self.send_error(400)
+                                return
                             km = re.search(r'(chunklist_\d+_\w+)', req_url)
                             type_key = km.group(1) if km else None
                             cdn_url = _proxy_state['url_map'].get(type_key, req_url) if type_key else req_url
+                            if not _is_allowed_remote_url(cdn_url):
+                                self.send_error(400)
+                                return
                             _proxy_state['last_request'] = time.time()
 
                             def _fetch_and_absolutize(u):


### PR DESCRIPTION
Potential fix for [https://github.com/rpeters1430/repository.dobbelina/security/code-scanning/174](https://github.com/rpeters1430/repository.dobbelina/security/code-scanning/174)

Best fix: enforce strict URL validation/allowlisting before creating outbound requests. In this file, the safest minimal functional change is to only allow `http`/`https` URLs whose hostname is `chaturbate.com` or a subdomain of it, and reject anything else with HTTP 400. This keeps existing behavior (fetching Chaturbate CDN/manifests) while removing full attacker-controlled destinations.

Apply changes in `plugin.video.cumination/resources/lib/sites/chaturbate.py` in the `/chunklist` handler:
- After `req_url` null-check and before it is used, parse and validate URL with a new helper.
- Also validate the final `cdn_url` before `_fetch_and_absolutize` (defense in depth, including mapped entries).
- Add a small local helper function `_is_allowed_remote_url(u)` in the handler scope (near `_fetch_and_absolutize`) using `urllib_parse.urlparse`.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
