### PR TITLE
Validate hostnames and block untrusted external URLs for Chaturbate and PornKai

### DIFF
--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -49,6 +49,30 @@ site = AdultSite(
 addon = utils.addon
 _cb_proxy = None
 _cb_proxy_state = None
+
+_ALLOWED_HOST_SUFFIXES = ("chaturbate.com",)
+
+
+def _host_matches(host, allowed_suffixes):
+    if not host:
+        return False
+    host = host.lower()
+    return any(host == suffix or host.endswith("." + suffix) for suffix in allowed_suffixes)
+
+
+def _is_allowed_chaturbate_url(url):
+    if not url:
+        return False
+    parsed = urllib_parse.urlsplit(url)
+    if parsed.scheme not in ("http", "https"):
+        return False
+    return _host_matches(parsed.hostname, _ALLOWED_HOST_SUFFIXES)
+
+
+def _reject_untrusted_url(url):
+    utils.kodilog("Chaturbate: blocked untrusted URL '{}'".format(url), xbmc.LOGWARNING)
+    utils.notify("Chaturbate", "Blocked non-Chaturbate URL")
+
 HTTP_HEADERS_IPAD = {
     "User-Agent": "Mozilla/5.0 (iPad; CPU OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B410 Safari/600.1.4"
 }
@@ -190,6 +214,11 @@ def Online(stamp):
 
 @site.register()
 def List(url, page=1):
+    if not _is_allowed_chaturbate_url(url):
+        _reject_untrusted_url(url)
+        utils.eod()
+        return
+
     if "follow=true" in url and "offline=false" in url:
         site.add_dir(
             "[COLOR yellow]Offline Rooms[/COLOR]",
@@ -334,6 +363,11 @@ def List(url, page=1):
 
 @site.register()
 def SList(url):
+    if not _is_allowed_chaturbate_url(url):
+        _reject_untrusted_url(url)
+        utils.eod()
+        return
+
     hdr = utils.base_hdrs.copy()
     hdr.update({"X-Requested-With": "XMLHttpRequest"})
     listhtml = utils._getHtml(url, site.url, headers=hdr)
@@ -396,6 +430,10 @@ def clean_database(showdialog=True):
 
 @site.register()
 def Playvid(url, name):
+    if not _is_allowed_chaturbate_url(url):
+        _reject_untrusted_url(url)
+        return
+
     playmode = int(addon.getSetting("chatplay"))
     try:
         listhtml, used_fs = utils.get_html_with_cloudflare_retry(
@@ -1150,11 +1188,19 @@ def Search(url, keyword=None):
     else:
         title = urllib_parse.quote_plus(keyword)
         url += title
+        if not _is_allowed_chaturbate_url(url):
+            _reject_untrusted_url(url)
+            return
         SList(url)
 
 
 @site.register()
 def topCams(url):
+    if not _is_allowed_chaturbate_url(url):
+        _reject_untrusted_url(url)
+        utils.eod()
+        return
+
     if addon.getSetting("chaturbate") == "true":
         clean_database(False)
     response = utils._getHtml(url)
@@ -1183,6 +1229,11 @@ def topCams(url):
 
 @site.register()
 def Tags(url, page=1):
+    if not _is_allowed_chaturbate_url(url):
+        _reject_untrusted_url(url)
+        utils.eod()
+        return
+
     cat = re.search(r"&g=([^&]*)", url).group(1)
     html = utils.getHtml(url, site.url)
     jdata = json.loads(html)

--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -57,7 +57,9 @@ def _host_matches(host, allowed_suffixes):
     if not host:
         return False
     host = host.lower()
-    return any(host == suffix or host.endswith("." + suffix) for suffix in allowed_suffixes)
+    return any(
+        host == suffix or host.endswith("." + suffix) for suffix in allowed_suffixes
+    )
 
 
 def _is_allowed_chaturbate_url(url):
@@ -72,6 +74,7 @@ def _is_allowed_chaturbate_url(url):
 def _reject_untrusted_url(url):
     utils.kodilog("Chaturbate: blocked untrusted URL '{}'".format(url), xbmc.LOGWARNING)
     utils.notify("Chaturbate", "Blocked non-Chaturbate URL")
+
 
 HTTP_HEADERS_IPAD = {
     "User-Agent": "Mozilla/5.0 (iPad; CPU OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B410 Safari/600.1.4"

--- a/plugin.video.cumination/resources/lib/sites/pornkai.py
+++ b/plugin.video.cumination/resources/lib/sites/pornkai.py
@@ -35,11 +35,14 @@ site = AdultSite(
     category="Video Tubes",
 )
 
+
 def _host_matches(host, allowed_suffixes):
     if not host:
         return False
     host = host.lower()
-    return any(host == suffix or host.endswith("." + suffix) for suffix in allowed_suffixes)
+    return any(
+        host == suffix or host.endswith("." + suffix) for suffix in allowed_suffixes
+    )
 
 
 def _is_allowed_site_url(url):
@@ -58,7 +61,6 @@ def _is_allowed_embed_url(url):
     if parsed.scheme not in ("http", "https"):
         return False
     return _host_matches(parsed.hostname, _ALLOWED_EMBED_HOST_SUFFIXES)
-
 
 
 @site.register(default_mode=True)
@@ -98,7 +100,9 @@ def List(url):
         markup, results_remaining = _extract_markup_and_meta(html)
     else:
         markup = html
-        results_remaining = 120  # Arbitrary positive value to show next page if HTML pagination exists
+        results_remaining = (
+            120  # Arbitrary positive value to show next page if HTML pagination exists
+        )
 
     soup = utils.parse_html(markup)
     video_items = soup.select("div.thumbnail, article.thumbnail")
@@ -325,7 +329,7 @@ def Categories(url):
         query = ""
         if "?q=" in caturl:
             query = caturl.split("?q=")[-1]
-        
+
         # API is currently 504ing, use HTML search instead
         if query:
             catpage = site.url + "videos?q={}&sort=best&page=1".format(query)
@@ -336,12 +340,6 @@ def Categories(url):
     utils.eod()
 
 
-
-
-
-
-
-
 @site.register()
 def Playvid(url, name, download=None):
     if not _is_allowed_site_url(url):
@@ -350,12 +348,14 @@ def Playvid(url, name, download=None):
 
     videohtml = utils.getHtml(url, site.url)
     soup = utils.parse_html(videohtml)
-    iframe = soup.select_one('.if_cont iframe, #video_container iframe, #player_container iframe')
+    iframe = soup.select_one(
+        ".if_cont iframe, #video_container iframe, #player_container iframe"
+    )
 
     vp = utils.VideoPlayer(name, download)
     if iframe:
-        vid_url = iframe.get('src', '')
-        if vid_url and vid_url.startswith('/'):
+        vid_url = iframe.get("src", "")
+        if vid_url and vid_url.startswith("/"):
             vid_url = urllib_parse.urljoin(site.url, vid_url)
         if _is_allowed_embed_url(vid_url):
             vp.play_from_link_to_resolve(vid_url)

--- a/plugin.video.cumination/resources/lib/sites/pornkai.py
+++ b/plugin.video.cumination/resources/lib/sites/pornkai.py
@@ -23,6 +23,9 @@ from resources.lib import utils
 from resources.lib.adultsite import AdultSite
 from six.moves import urllib_parse
 
+_ALLOWED_HOST_SUFFIXES = ("pornkai.com",)
+_ALLOWED_EMBED_HOST_SUFFIXES = ("xvideos.com", "xh.video")
+
 site = AdultSite(
     "pornkai",
     "[COLOR hotpink]PornKai[/COLOR]",
@@ -31,6 +34,31 @@ site = AdultSite(
     "pornkai",
     category="Video Tubes",
 )
+
+def _host_matches(host, allowed_suffixes):
+    if not host:
+        return False
+    host = host.lower()
+    return any(host == suffix or host.endswith("." + suffix) for suffix in allowed_suffixes)
+
+
+def _is_allowed_site_url(url):
+    if not url:
+        return False
+    parsed = urllib_parse.urlsplit(url)
+    if parsed.scheme not in ("http", "https"):
+        return False
+    return _host_matches(parsed.hostname, _ALLOWED_HOST_SUFFIXES)
+
+
+def _is_allowed_embed_url(url):
+    if not url:
+        return False
+    parsed = urllib_parse.urlsplit(url)
+    if parsed.scheme not in ("http", "https"):
+        return False
+    return _host_matches(parsed.hostname, _ALLOWED_EMBED_HOST_SUFFIXES)
+
 
 
 @site.register(default_mode=True)
@@ -55,6 +83,11 @@ def Main():
 
 @site.register()
 def List(url):
+    if not _is_allowed_site_url(url):
+        utils.notify("PornKai", "Blocked non-PornKai URL")
+        utils.eod()
+        return
+
     html = utils.getHtml(url, site.url)
     if not html:
         utils.eod()
@@ -232,6 +265,10 @@ def _add_next_page(url, results_remaining):
 
 @site.register()
 def Related(url):
+    if not _is_allowed_site_url(url):
+        utils.notify("PornKai", "Blocked non-PornKai URL")
+        return
+
     contexturl = (
         utils.addon_sys
         + "?mode="
@@ -253,6 +290,11 @@ def Search(url, keyword=None):
 
 @site.register()
 def Categories(url):
+    if not _is_allowed_site_url(url):
+        utils.notify("PornKai", "Blocked non-PornKai URL")
+        utils.eod()
+        return
+
     cathtml = utils.getHtml(url)
     if not cathtml:
         utils.eod()
@@ -302,6 +344,10 @@ def Categories(url):
 
 @site.register()
 def Playvid(url, name, download=None):
+    if not _is_allowed_site_url(url):
+        utils.notify("PornKai", "Blocked non-PornKai URL")
+        return
+
     videohtml = utils.getHtml(url, site.url)
     soup = utils.parse_html(videohtml)
     iframe = soup.select_one('.if_cont iframe, #video_container iframe, #player_container iframe')
@@ -309,10 +355,11 @@ def Playvid(url, name, download=None):
     vp = utils.VideoPlayer(name, download)
     if iframe:
         vid_url = iframe.get('src', '')
-        if vid_url:
-            if 'xvideos.com' in vid_url or 'xh.video' in vid_url:
-                vp.play_from_link_to_resolve(vid_url)
-                return
+        if vid_url and vid_url.startswith('/'):
+            vid_url = urllib_parse.urljoin(site.url, vid_url)
+        if _is_allowed_embed_url(vid_url):
+            vp.play_from_link_to_resolve(vid_url)
+            return
 
     # Fallback to the original method if iframe not found or src is not a direct link
     vp.play_from_html(videohtml, url)


### PR DESCRIPTION
### Motivation
- Prevent loading or acting on URLs that are not hosted on the intended sites to reduce security and privacy risks.
- Block untrusted embedded players or redirects to third-party hosts to avoid remote content injection and unexpected resolution behavior.
- Normalize iframe handling so relative `src` attributes are resolved and only approved embed hosts are allowed.

### Description
- Added allowed host suffix constants and host-matching helpers (`_ALLOWED_HOST_SUFFIXES`, `_host_matches`, `_is_allowed_chaturbate_url`) to `chaturbate.py` and corresponding helpers (`_ALLOWED_HOST_SUFFIXES`, `_ALLOWED_EMBED_HOST_SUFFIXES`, `_is_allowed_site_url`, `_is_allowed_embed_url`) to `pornkai.py`.
- Added pre-flight validation in site entry points to block non-site URLs in `chaturbate.py` (`List`, `SList`, `Playvid`, `Search`, `topCams`, `Tags`) and in `pornkai.py` (`List`, `Related`, `Categories`, `Playvid`), with logging and user notification when blocked (`_reject_untrusted_url` / `utils.notify`).
- Replaced hard-coded embed host checks in `pornkai.Playvid` with `_is_allowed_embed_url`, resolve relative iframe `src` via `urllib_parse.urljoin`, and fall back to `play_from_html` when no approved embed is found.
- Minor logging/notification additions and early exits (`utils.eod()` or `return`) to avoid further processing of blocked URLs.

### Testing
- Ran project static import and lint checks to ensure new helpers and imports do not break module loading, and they succeeded.
- Exercised the main site flows (`Main`, `List`, `Playvid`) in a local smoke test to confirm blocked non-site URLs trigger notifications and valid site flows continue, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7aca820c083278d8d5d5b84d4ec96)