### PR TITLE
Potential fix for code scanning alert no. 177: Incomplete URL substring sanitization

### DIFF
--- a/plugin.video.cumination/resources/lib/sites/premiumporn.py
+++ b/plugin.video.cumination/resources/lib/sites/premiumporn.py
@@ -251,13 +251,18 @@ def Play(url, name, download=None):
                             pass
                 utils.notify("Oh oh", "Unable to retrieve video URL from Vidara")
                 return
-            elif "bysewihe" in embed_url or "g9r6.com" in embed_url:
-                id_match = re.search(r"/e/([^/]+)", embed_url)
-                if id_match:
-                    video_id = id_match.group(1)
-                    details_url = "https://bysewihe.com/api/videos/{}/embed/details".format(
-                        video_id
-                    )
+            else:
+                parsed_embed = urllib_parse.urlparse(embed_url)
+                embed_host = (parsed_embed.hostname or "").lower()
+                is_bysewihe_host = embed_host == "bysewihe.com" or embed_host.endswith(".bysewihe.com")
+                is_g9r6_host = embed_host == "g9r6.com" or embed_host.endswith(".g9r6.com")
+                if is_bysewihe_host or is_g9r6_host:
+                    id_match = re.search(r"/e/([^/]+)", embed_url)
+                    if id_match:
+                        video_id = id_match.group(1)
+                        details_url = "https://bysewihe.com/api/videos/{}/embed/details".format(
+                            video_id
+                        )
                     hdr = utils.base_hdrs.copy()
                     hdr["X-Embed-Origin"] = "premiumporn.org"
                     hdr["X-Embed-Parent"] = embed_url

--- a/plugin.video.cumination/resources/lib/sites/premiumporn.py
+++ b/plugin.video.cumination/resources/lib/sites/premiumporn.py
@@ -110,7 +110,9 @@ def List(url):
         )
 
     # Fixed next page selector
-    next_link = soup.select_one(".page-numbers.current + a, a.next.page-numbers, a.next.page-link[href]")
+    next_link = soup.select_one(
+        ".page-numbers.current + a, a.next.page-numbers, a.next.page-link[href]"
+    )
     if next_link:
         next_url = utils.safe_get_attr(next_link, "href", default="")
         if next_url:
@@ -137,7 +139,7 @@ def Categories(url):
         img_tag = item.select_one("img")
         img = utils.safe_get_attr(img_tag, "src", ["data-src"])
         name = utils.safe_get_attr(img_tag, "alt", default=utils.safe_get_text(item))
-        
+
         videos = ""
         count_tag = item.select_one(".video-datas, .count")
         if count_tag:
@@ -150,9 +152,14 @@ def Categories(url):
 
         if not siteurl or not name:
             continue
-            
+
         if videos:
-            name = utils.cleantext(name) + "[COLOR hotpink] (" + videos + " videos)[/COLOR]"
+            name = (
+                utils.cleantext(name)
+                + "[COLOR hotpink] ("
+                + videos
+                + " videos)[/COLOR]"
+            )
         else:
             name = utils.cleantext(name)
 
@@ -254,14 +261,20 @@ def Play(url, name, download=None):
             else:
                 parsed_embed = urllib_parse.urlparse(embed_url)
                 embed_host = (parsed_embed.hostname or "").lower()
-                is_bysewihe_host = embed_host == "bysewihe.com" or embed_host.endswith(".bysewihe.com")
-                is_g9r6_host = embed_host == "g9r6.com" or embed_host.endswith(".g9r6.com")
+                is_bysewihe_host = embed_host == "bysewihe.com" or embed_host.endswith(
+                    ".bysewihe.com"
+                )
+                is_g9r6_host = embed_host == "g9r6.com" or embed_host.endswith(
+                    ".g9r6.com"
+                )
                 if is_bysewihe_host or is_g9r6_host:
                     id_match = re.search(r"/e/([^/]+)", embed_url)
                     if id_match:
                         video_id = id_match.group(1)
-                        details_url = "https://bysewihe.com/api/videos/{}/embed/details".format(
-                            video_id
+                        details_url = (
+                            "https://bysewihe.com/api/videos/{}/embed/details".format(
+                                video_id
+                            )
                         )
                     hdr = utils.base_hdrs.copy()
                     hdr["X-Embed-Origin"] = "premiumporn.org"
@@ -271,8 +284,10 @@ def Play(url, name, download=None):
                     if details_data:
                         details_json = json.loads(details_data)
                         embed = details_json.get("embed_frame_url", "")
-                        api_url = "https://g9r6.com/api/videos/{}/embed/playback".format(
-                            video_id
+                        api_url = (
+                            "https://g9r6.com/api/videos/{}/embed/playback".format(
+                                video_id
+                            )
                         )
                         api_data = utils.getHtml(api_url, embed, headers=hdr)
                         if api_data:
@@ -290,13 +305,17 @@ def Play(url, name, download=None):
                             try:
                                 src_api = {}
                                 for source in json.loads(result).get("sources", []):
-                                    v_url = source.get("url", "").replace("\\u0026", "&")
+                                    v_url = source.get("url", "").replace(
+                                        "\\u0026", "&"
+                                    )
                                     label = source.get("label", "")
                                     src_api[label] = v_url
 
                                 video_url = utils.prefquality(
                                     src_api,
-                                    sort_by=lambda x: 2160 if x == "4k" else int(x[:-1]),
+                                    sort_by=lambda x: 2160
+                                    if x == "4k"
+                                    else int(x[:-1]),
                                     reverse=True,
                                 )
                                 if video_url:


### PR DESCRIPTION
Potential fix for [https://github.com/rpeters1430/repository.dobbelina/security/code-scanning/177](https://github.com/rpeters1430/repository.dobbelina/security/code-scanning/177)

Use parsed URL hostname validation instead of substring checks on the full URL string.

Best fix in this snippet:
- In `plugin.video.cumination/resources/lib/sites/premiumporn.py`, inside `Play(...)` near line 254, parse `embed_url` with `urllib_parse.urlparse`.
- Extract and normalize `hostname`.
- Replace `elif "bysewihe" in embed_url or "g9r6.com" in embed_url:` with a host-based condition that only accepts intended hosts (exact `g9r6.com`, exact `bysewihe.com`, or their subdomains).
- Keep existing behavior/functionality otherwise unchanged.

No new dependencies are needed; `urllib_parse` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
